### PR TITLE
Remove experimental examples and internalize temporal rule result

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ func main() {
         goat.WithStateMachines(sm),
         goat.WithConditions(cond),
         goat.WithInvariants(cond),
+        goat.WithTemporalRules(
+            goat.WheneverPEventuallyQ(cond, cond),
+            goat.EventuallyAlways(cond),
+            goat.AlwaysEventually(cond),
+        ),
     )
     if err != nil {
         panic(err)
@@ -82,6 +87,7 @@ func main() {
 - **`WithStateMachines()`** - Configure which state machines to test
 - **`WithConditions()`** - Register named conditions
 - **`WithInvariants()`** - Configure conditions to check as invariants
+- **`WithTemporalRules()`** - Register temporal rules to verify temporal properties
 
 ## Examples
 

--- a/ltl.go
+++ b/ltl.go
@@ -1,0 +1,202 @@
+package goat
+
+// ltl.go contains internal logic for evaluating temporal rules using
+// Büchi automata. These details are hidden from users of the library but
+// exposed for contributors.
+
+type baState int
+
+type baTransition struct {
+	to   baState
+	cond func(map[ConditionName]bool) bool
+}
+
+type ba struct {
+	initial   baState
+	accepting map[baState]bool
+	trans     map[baState][]baTransition
+}
+
+type lasso struct {
+	Prefix []worldID `json:"prefix"`
+	Loop   []worldID `json:"loop"`
+}
+
+func (m *model) checkLTL() []temporalRuleResult {
+	results := make([]temporalRuleResult, 0, len(m.ltlRules))
+	for _, r := range m.ltlRules {
+		holds, lasso := m.checkBA(r.ba())
+		results = append(results, temporalRuleResult{Rule: r.name(), Holds: holds, Lasso: lasso})
+	}
+	return results
+}
+
+type prodNode struct {
+	w worldID
+	s baState
+}
+
+func (m *model) checkBA(b *ba) (bool, *lasso) {
+	start := prodNode{w: m.initial.id, s: b.initial}
+	graph := make(map[prodNode][]prodNode)
+	pre := map[prodNode]prodNode{start: start}
+	queue := []prodNode{start}
+
+	for len(queue) > 0 {
+		n := queue[0]
+		queue = queue[1:]
+		labels := m.labels[n.w]
+		succs := m.accessible[n.w]
+		if len(succs) == 0 {
+			succs = []worldID{n.w}
+		}
+		for _, w2 := range succs {
+			for _, tr := range b.trans[n.s] {
+				if tr.cond(labels) {
+					next := prodNode{w: w2, s: tr.to}
+					graph[n] = append(graph[n], next)
+					if _, ok := pre[next]; !ok {
+						pre[next] = n
+						queue = append(queue, next)
+					}
+				}
+			}
+		}
+	}
+
+	for node := range pre {
+		if _, ok := graph[node]; !ok {
+			graph[node] = nil
+		}
+	}
+
+	sccs := sccProduct(graph)
+	for _, scc := range sccs {
+		if !isProdCyclic(scc, graph) {
+			continue
+		}
+		for _, n := range scc {
+			if b.accepting[n.s] {
+				prefix := buildPrefix(pre, n)
+				sccSet := make(map[prodNode]bool)
+				for _, pn := range scc {
+					sccSet[pn] = true
+				}
+				loop := findCycle(graph, n, sccSet)
+				if loop == nil {
+					loop = []worldID{n.w}
+				}
+				return false, &lasso{Prefix: prefix, Loop: loop}
+			}
+		}
+	}
+	return true, nil
+}
+
+func buildPrefix(pre map[prodNode]prodNode, to prodNode) []worldID {
+	path := []prodNode{to}
+	for pre[to] != to {
+		to = pre[to]
+		path = append([]prodNode{to}, path...)
+	}
+	res := make([]worldID, len(path))
+	for i, n := range path {
+		res[i] = n.w
+	}
+	return res
+}
+
+func findCycle(graph map[prodNode][]prodNode, start prodNode, scc map[prodNode]bool) []worldID {
+	queue := []prodNode{start}
+	pre := map[prodNode]prodNode{start: start}
+	for len(queue) > 0 {
+		v := queue[0]
+		queue = queue[1:]
+		for _, n := range graph[v] {
+			if !scc[n] {
+				continue
+			}
+			if _, ok := pre[n]; ok {
+				continue
+			}
+			pre[n] = v
+			if n == start {
+				nodes := []prodNode{n}
+				for pre[n] != n {
+					n = pre[n]
+					nodes = append([]prodNode{n}, nodes...)
+				}
+				loop := make([]worldID, len(nodes)-1)
+				for i := 0; i < len(nodes)-1; i++ {
+					loop[i] = nodes[i].w
+				}
+				return loop
+			}
+			queue = append(queue, n)
+		}
+	}
+	return nil
+}
+
+func sccProduct(graph map[prodNode][]prodNode) [][]prodNode {
+	index := 0
+	stack := []prodNode{}
+	indices := make(map[prodNode]int)
+	lowlink := make(map[prodNode]int)
+	onStack := make(map[prodNode]bool)
+	var result [][]prodNode
+
+	var strongConnect func(v prodNode)
+	strongConnect = func(v prodNode) {
+		indices[v] = index
+		lowlink[v] = index
+		index++
+		stack = append(stack, v)
+		onStack[v] = true
+
+		for _, w := range graph[v] {
+			if _, ok := indices[w]; !ok {
+				strongConnect(w)
+				if lowlink[w] < lowlink[v] {
+					lowlink[v] = lowlink[w]
+				}
+			} else if onStack[w] && indices[w] < lowlink[v] {
+				lowlink[v] = indices[w]
+			}
+		}
+
+		if lowlink[v] == indices[v] {
+			var scc []prodNode
+			for {
+				w := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[w] = false
+				scc = append(scc, w)
+				if w == v {
+					break
+				}
+			}
+			result = append(result, scc)
+		}
+	}
+
+	for v := range graph {
+		if _, ok := indices[v]; !ok {
+			strongConnect(v)
+		}
+	}
+	return result
+}
+
+func isProdCyclic(scc []prodNode, graph map[prodNode][]prodNode) bool {
+	if len(scc) > 1 {
+		return true
+	}
+	n := scc[0]
+	for _, m := range graph[n] {
+		if m == n {
+			return true
+		}
+	}
+	return false
+}

--- a/model.go
+++ b/model.go
@@ -14,6 +14,7 @@ type model struct {
 	accessible map[worldID][]worldID
 	conds      map[ConditionName]Condition
 	invariants []ConditionName
+	ltlRules   []TemporalRule
 	labels     map[worldID]map[ConditionName]bool
 }
 
@@ -186,6 +187,7 @@ func newModel(opts ...Option) (model, error) {
 		accessible: make(map[worldID][]worldID),
 		conds:      os.conds,
 		invariants: os.invariants,
+		ltlRules:   os.ltlRules,
 		labels:     make(map[worldID]map[ConditionName]bool),
 	}
 	m.labelWorld(initial)
@@ -246,6 +248,7 @@ type options struct {
 	sms        []AbstractStateMachine
 	conds      map[ConditionName]Condition
 	invariants []ConditionName
+	ltlRules   []TemporalRule
 }
 
 // Option is a configuration option for model checking operations.

--- a/temporal_rule.go
+++ b/temporal_rule.go
@@ -1,0 +1,153 @@
+package goat
+
+import "fmt"
+
+// TemporalRule represents a temporal property specified by a Büchi automaton.
+type TemporalRule interface {
+	name() string
+	ba() *ba
+}
+
+type temporalRule struct {
+	n string
+	b *ba
+}
+
+func (r temporalRule) name() string { return r.n }
+func (r temporalRule) ba() *ba      { return r.b }
+
+type temporalRuleResult struct {
+	Rule  string `json:"rule"`
+	Holds bool   `json:"holds"`
+	Lasso *lasso `json:"lasso,omitempty"`
+}
+
+// WithTemporalRules registers temporal rules for model checking.
+//
+// Parameters:
+//   - rs: The temporal rules to enforce during verification
+//
+// Returns an Option that can be passed to Test or Debug.
+//
+// Example:
+//
+//	err := goat.Test(
+//	    goat.WithStateMachines(sm),
+//	    goat.WithTemporalRules(goat.EventuallyAlways(cond)),
+//	)
+func WithTemporalRules(rs ...TemporalRule) Option {
+	return optionFunc(func(o *options) {
+		o.ltlRules = append(o.ltlRules, rs...)
+	})
+}
+
+// ---------- Temporal rule constructors ----------
+
+// WheneverPEventuallyQ returns a rule enforcing that whenever p holds, q eventually holds.
+//
+// Parameters:
+//   - p: Condition that triggers the obligation
+//   - q: Condition that must eventually become true
+//
+// Returns a TemporalRule that can be registered with WithTemporalRules.
+//
+// Example:
+//
+//	rule := goat.WheneverPEventuallyQ(write, replicated)
+//	err := goat.Test(
+//	    goat.WithStateMachines(primary, replica),
+//	    goat.WithConditions(write, replicated),
+//	    goat.WithTemporalRules(rule),
+//	)
+func WheneverPEventuallyQ(p, q Condition) TemporalRule {
+	name := fmt.Sprintf("whenever %s eventually %s", p.Name(), q.Name())
+	b := &ba{
+		initial:   0,
+		accepting: map[baState]bool{1: true},
+		trans: map[baState][]baTransition{
+			0: {
+				{to: 1, cond: func(l map[ConditionName]bool) bool { return l[p.Name()] && !l[q.Name()] }},
+				{to: 0, cond: func(l map[ConditionName]bool) bool { return !(l[p.Name()] && !l[q.Name()]) }},
+			},
+			1: {
+				{to: 1, cond: func(l map[ConditionName]bool) bool { return !l[q.Name()] }},
+				{to: 2, cond: func(l map[ConditionName]bool) bool { return l[q.Name()] }},
+			},
+			2: {
+				{to: 2, cond: func(map[ConditionName]bool) bool { return true }},
+			},
+		},
+	}
+	return temporalRule{n: name, b: b}
+}
+
+// EventuallyAlways returns a rule enforcing that c eventually holds forever.
+//
+// Parameters:
+//   - c: Condition that must eventually remain true
+//
+// Returns a TemporalRule that can be registered with WithTemporalRules.
+//
+// Example:
+//
+//	rule := goat.EventuallyAlways(stable)
+//	err := goat.Test(
+//	    goat.WithStateMachines(nodes...),
+//	    goat.WithConditions(stable),
+//	    goat.WithTemporalRules(rule),
+//	)
+func EventuallyAlways(c Condition) TemporalRule {
+	name := fmt.Sprintf("eventually always %s", c.Name())
+	b := &ba{
+		initial:   0,
+		accepting: map[baState]bool{1: true},
+		trans: map[baState][]baTransition{
+			0: {
+				{to: 1, cond: func(l map[ConditionName]bool) bool { return !l[c.Name()] }},
+				{to: 0, cond: func(l map[ConditionName]bool) bool { return l[c.Name()] }},
+			},
+			1: {
+				{to: 1, cond: func(l map[ConditionName]bool) bool { return !l[c.Name()] }},
+				{to: 0, cond: func(l map[ConditionName]bool) bool { return l[c.Name()] }},
+			},
+		},
+	}
+	return temporalRule{n: name, b: b}
+}
+
+// AlwaysEventually returns a rule enforcing that c holds infinitely often.
+//
+// Parameters:
+//   - c: Condition that must recur indefinitely
+//
+// Returns a TemporalRule that can be registered with WithTemporalRules.
+//
+// Example:
+//
+//	rule := goat.AlwaysEventually(heartbeat)
+//	err := goat.Test(
+//	    goat.WithStateMachines(node),
+//	    goat.WithConditions(heartbeat),
+//	    goat.WithTemporalRules(rule),
+//	)
+func AlwaysEventually(c Condition) TemporalRule {
+	name := fmt.Sprintf("always eventually %s", c.Name())
+	b := &ba{
+		initial:   0,
+		accepting: map[baState]bool{1: true},
+		trans: map[baState][]baTransition{
+			0: {
+				{to: 1, cond: func(l map[ConditionName]bool) bool { return !l[c.Name()] }},
+				{to: 0, cond: func(map[ConditionName]bool) bool { return true }},
+			},
+			1: {
+				{to: 1, cond: func(l map[ConditionName]bool) bool { return !l[c.Name()] }},
+				{to: 2, cond: func(l map[ConditionName]bool) bool { return l[c.Name()] }},
+			},
+			2: {
+				{to: 2, cond: func(map[ConditionName]bool) bool { return true }},
+			},
+		},
+	}
+	return temporalRule{n: name, b: b}
+}

--- a/temporal_rule_test.go
+++ b/temporal_rule_test.go
@@ -1,0 +1,163 @@
+package goat
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestTemporalRule_EventuallyAlways(t *testing.T) {
+	t.Run("holds", func(t *testing.T) {
+		sm := newTestStateMachine(newTestState("s"))
+		cTrue := BoolCondition("c", true)
+		m, err := newModel(
+			WithStateMachines(sm),
+			WithConditions(cTrue),
+			WithTemporalRules(EventuallyAlways(cTrue)),
+		)
+		if err != nil {
+			t.Fatalf("newModel error: %v", err)
+		}
+		_ = m.Solve()
+		res := m.checkLTL()
+		if !res[0].Holds {
+			t.Fatalf("expected rule to hold")
+		}
+	})
+
+	t.Run("violation", func(t *testing.T) {
+		sm := newTestStateMachine(newTestState("s"))
+		cFalse := BoolCondition("cF", false)
+		m, err := newModel(
+			WithStateMachines(sm),
+			WithConditions(cFalse),
+			WithTemporalRules(EventuallyAlways(cFalse)),
+		)
+		if err != nil {
+			t.Fatalf("newModel error: %v", err)
+		}
+		_ = m.Solve()
+		res := m.checkLTL()
+		if res[0].Holds {
+			t.Fatalf("expected rule violation")
+		}
+		if res[0].Lasso == nil {
+			t.Fatalf("expected lasso")
+		}
+	})
+}
+
+func TestTemporalRule_AlwaysEventually(t *testing.T) {
+	t.Run("holds", func(t *testing.T) {
+		sm := newTestStateMachine(newTestState("s"))
+		cTrue := BoolCondition("c", true)
+		m, err := newModel(
+			WithStateMachines(sm),
+			WithConditions(cTrue),
+			WithTemporalRules(AlwaysEventually(cTrue)),
+		)
+		if err != nil {
+			t.Fatalf("newModel error: %v", err)
+		}
+		_ = m.Solve()
+		res := m.checkLTL()
+		if !res[0].Holds {
+			t.Fatalf("expected rule to hold")
+		}
+	})
+
+	t.Run("violation", func(t *testing.T) {
+		sm := newTestStateMachine(newTestState("s"))
+		cFalse := BoolCondition("cF", false)
+		m, err := newModel(
+			WithStateMachines(sm),
+			WithConditions(cFalse),
+			WithTemporalRules(AlwaysEventually(cFalse)),
+		)
+		if err != nil {
+			t.Fatalf("newModel error: %v", err)
+		}
+		_ = m.Solve()
+		res := m.checkLTL()
+		if res[0].Holds {
+			t.Fatalf("expected rule violation")
+		}
+		if res[0].Lasso == nil {
+			t.Fatalf("expected lasso")
+		}
+	})
+}
+
+func TestTemporalRule_WheneverPEventuallyQ(t *testing.T) {
+	t.Run("holds", func(t *testing.T) {
+		sm := newTestStateMachine(newTestState("s"))
+		pTrue := BoolCondition("p", true)
+		qTrue := BoolCondition("q", true)
+		m, err := newModel(
+			WithStateMachines(sm),
+			WithConditions(pTrue, qTrue),
+			WithTemporalRules(WheneverPEventuallyQ(pTrue, qTrue)),
+		)
+		if err != nil {
+			t.Fatalf("newModel error: %v", err)
+		}
+		_ = m.Solve()
+		res := m.checkLTL()
+		if !res[0].Holds {
+			t.Fatalf("expected rule to hold")
+		}
+	})
+
+	t.Run("violation", func(t *testing.T) {
+		sm := newTestStateMachine(newTestState("s"))
+		pTrue := BoolCondition("p", true)
+		qFalse := BoolCondition("q", false)
+		m, err := newModel(
+			WithStateMachines(sm),
+			WithConditions(pTrue, qFalse),
+			WithTemporalRules(WheneverPEventuallyQ(pTrue, qFalse)),
+		)
+		if err != nil {
+			t.Fatalf("newModel error: %v", err)
+		}
+		_ = m.Solve()
+		res := m.checkLTL()
+		if res[0].Holds {
+			t.Fatalf("expected rule violation")
+		}
+		if res[0].Lasso == nil {
+			t.Fatalf("expected lasso")
+		}
+	})
+}
+
+func TestTemporalRuleIntegration_Test(t *testing.T) {
+	sm := newTestStateMachine(newTestState("s"))
+	cFalse := BoolCondition("c", false)
+	err := Test(
+		WithStateMachines(sm),
+		WithConditions(cFalse),
+		WithTemporalRules(EventuallyAlways(cFalse)),
+	)
+	if err == nil {
+		t.Fatalf("expected error from Test")
+	}
+}
+
+func TestTemporalRuleIntegration_Debug(t *testing.T) {
+	sm := newTestStateMachine(newTestState("s"))
+	cFalse := BoolCondition("c", false)
+	var buf bytes.Buffer
+	err := Debug(&buf,
+		WithStateMachines(sm),
+		WithConditions(cFalse),
+		WithTemporalRules(EventuallyAlways(cFalse)),
+	)
+	if err != nil {
+		t.Fatalf("Debug error: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "temporal_rules") {
+		t.Fatalf("expected temporal_rules in debug output")
+	}
+}


### PR DESCRIPTION
## Summary
- drop the experimental db-deadlock, eventual consistency, and raft examples
- tidy the README example list to match the remaining scenarios
- hide TemporalRuleResult to keep temporal rule evaluation internal
- remove doc comments from unexported functions to follow style guidance
- document the WithTemporalRules API and rule constructors in godoc format
- refactor temporal rule tests to inline single-state machines and use subtests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c6a16fa26083318c83a297bf1b0896