### PR TITLE
fix: satisfy lint rules

### DIFF
--- a/example/temporal-rule/diagram.dot
+++ b/example/temporal-rule/diagram.dot
@@ -1,0 +1,55 @@
+digraph {
+  1323071071906196919 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Pending}
+
+QueuedEvents:
+StateMachine << transitionEvent; {Name:To,Type:goat.AbstractState,Value:&{{0} Paid}}
+StateMachine << entryEvent;" ];
+  5697576419907670381 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Paid}
+
+QueuedEvents:
+StateMachine << transitionEvent; {Name:To,Type:goat.AbstractState,Value:&{{0} Shipped}}
+StateMachine << entryEvent;" ];
+  6633226742058791819 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Shipped}
+
+QueuedEvents:" ];
+  7715228447041403726 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Pending}
+
+QueuedEvents:
+StateMachine << exitEvent;
+StateMachine << transitionEvent; {Name:To,Type:goat.AbstractState,Value:&{{0} Paid}}
+StateMachine << entryEvent;" ];
+  12177598604574514884 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Pending}
+
+QueuedEvents:
+StateMachine << entryEvent;" ];
+  12177598604574514884 [ penwidth=5 ];
+  12591507039532100162 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Paid}
+
+QueuedEvents:
+StateMachine << exitEvent;
+StateMachine << transitionEvent; {Name:To,Type:goat.AbstractState,Value:&{{0} Shipped}}
+StateMachine << entryEvent;" ];
+  15120067478055564299 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Paid}
+
+QueuedEvents:
+StateMachine << entryEvent;" ];
+  15821376834768749708 [ label="StateMachines:
+StateMachine = no fields; State: {Name:StateType,Type:main.StateType,Value:Shipped}
+
+QueuedEvents:
+StateMachine << entryEvent;" ];
+  1323071071906196919 -> 15120067478055564299;
+  5697576419907670381 -> 15821376834768749708;
+  7715228447041403726 -> 1323071071906196919;
+  12177598604574514884 -> 7715228447041403726;
+  12591507039532100162 -> 5697576419907670381;
+  15120067478055564299 -> 12591507039532100162;
+  15821376834768749708 -> 6633226742058791819;
+}

--- a/example/temporal-rule/expected_worlds.json
+++ b/example/temporal-rule/expected_worlds.json
@@ -1,0 +1,426 @@
+[
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "eShipResponse",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "exitEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "{Name:To,Type:goat.AbstractState,Value:\u0026{{0} Shipped}}",
+        "event_name": "transitionEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "{Name:To,Type:goat.AbstractState,Value:\u0026{{0} Shipped}}",
+        "event_name": "transitionEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Shipper"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "eShipRequest",
+        "target_machine": "Shipper"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "eShipRequest",
+        "target_machine": "Shipper"
+      },
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Shipper"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Paid}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Pending}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "exitEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "{Name:To,Type:goat.AbstractState,Value:\u0026{{0} Paid}}",
+        "event_name": "transitionEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Pending}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "exitEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "{Name:To,Type:goat.AbstractState,Value:\u0026{{0} Paid}}",
+        "event_name": "transitionEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Shipper"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Pending}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "{Name:To,Type:goat.AbstractState,Value:\u0026{{0} Paid}}",
+        "event_name": "transitionEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Pending}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "{Name:To,Type:goat.AbstractState,Value:\u0026{{0} Paid}}",
+        "event_name": "transitionEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Shipper"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Pending}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      },
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Shipper"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Pending}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Shipped}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  },
+  {
+    "invariant_violation": false,
+    "queued_events": [
+      {
+        "details": "no fields",
+        "event_name": "entryEvent",
+        "target_machine": "Order"
+      }
+    ],
+    "state_machines": [
+      {
+        "details": "no fields",
+        "id": "Order",
+        "name": "Order",
+        "state": "{Name:StateType,Type:main.StateType,Value:Shipped}"
+      },
+      {
+        "details": "no fields",
+        "id": "Shipper",
+        "name": "Shipper",
+        "state": "no fields"
+      }
+    ]
+  }
+]

--- a/example/temporal-rule/main.go
+++ b/example/temporal-rule/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	"github.com/goatx/goat"
+)
+
+type (
+	StateType string
+)
+
+const (
+	StatePending StateType = "Pending"
+	StatePaid    StateType = "Paid"
+	StateShipped StateType = "Shipped"
+)
+
+type (
+	eShipRequest struct {
+		goat.Event
+		From *Order
+	}
+	eShipResponse struct{ goat.Event }
+)
+
+type (
+	State struct {
+		goat.State
+		StateType StateType
+	}
+	Order struct {
+		goat.StateMachine
+		Shipper *Shipper
+	}
+)
+
+type (
+	shipperState struct{ goat.State }
+	Shipper      struct{ goat.StateMachine }
+)
+
+func createTemporalRuleModel() []goat.Option {
+	// === Shipper Spec ===
+	shipperSpec := goat.NewStateMachineSpec(&Shipper{})
+	idle := &shipperState{}
+	shipperSpec.DefineStates(idle).SetInitialState(idle)
+	goat.OnEvent(shipperSpec, idle, &eShipRequest{}, func(ctx context.Context, e *eShipRequest, _ *Shipper) {
+		goat.SendTo(ctx, e.From, &eShipResponse{})
+	})
+
+	// === Order Spec ===
+	orderSpec := goat.NewStateMachineSpec(&Order{})
+	pending := &State{StateType: StatePending}
+	paid := &State{StateType: StatePaid}
+	shipped := &State{StateType: StateShipped}
+
+	orderSpec.DefineStates(pending, paid, shipped).SetInitialState(pending)
+
+	goat.OnEntry(orderSpec, pending, func(ctx context.Context, _ *Order) {
+		goat.Goto(ctx, paid)
+	})
+	goat.OnEntry(orderSpec, paid, func(ctx context.Context, o *Order) {
+		goat.SendTo(ctx, o.Shipper, &eShipRequest{From: o})
+	})
+	goat.OnEvent(orderSpec, paid, &eShipResponse{}, func(ctx context.Context, _ *eShipResponse, o *Order) {
+		goat.Goto(ctx, shipped)
+	})
+
+	// === Create Instances ===
+	shipper, err := shipperSpec.NewInstance()
+	if err != nil {
+		log.Fatal(err)
+	}
+	order, err := orderSpec.NewInstance()
+	if err != nil {
+		log.Fatal(err)
+	}
+	order.Shipper = shipper
+
+	inPaid := goat.NewCondition("inPaid", order, func(o *Order) bool {
+		return o.State.(*State).StateType == StatePaid
+	})
+	inShipped := goat.NewCondition("inShipped", order, func(o *Order) bool {
+		return o.State.(*State).StateType == StateShipped
+	})
+
+	rule := goat.WheneverPEventuallyQ(inPaid, inShipped)
+
+	opts := []goat.Option{
+		goat.WithStateMachines(shipper, order),
+		goat.WithConditions(inPaid, inShipped),
+		goat.WithTemporalRules(rule),
+	}
+
+	return opts
+}
+
+func main() {
+	opts := createTemporalRuleModel()
+	if err := goat.Test(opts...); err != nil {
+		panic(err)
+	}
+}

--- a/example/temporal-rule/main_test.go
+++ b/example/temporal-rule/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/goatx/goat"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestTemporalRuleExample(t *testing.T) {
+	opts := createTemporalRuleModel()
+
+	var buf bytes.Buffer
+	if err := goat.Debug(&buf, opts...); err != nil {
+		t.Fatalf("Debug failed: %v", err)
+	}
+
+	var data map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &data); err != nil {
+		t.Fatalf("Failed to parse JSON: %v", err)
+	}
+
+	expectedWorldsData, err := os.ReadFile("expected_worlds.json")
+	if err != nil {
+		t.Fatalf("Failed to read expected worlds file: %v", err)
+	}
+
+	var expectedWorlds any
+	if err := json.Unmarshal(expectedWorldsData, &expectedWorlds); err != nil {
+		t.Fatalf("Failed to parse expected worlds JSON: %v", err)
+	}
+
+	cmpOpts := cmp.Options{
+		cmpopts.IgnoreMapEntries(func(k, v any) bool {
+			key, ok := k.(string)
+			return ok && key == "summary"
+		}),
+	}
+
+	if diff := cmp.Diff(expectedWorlds, data["worlds"], cmpOpts...); diff != "" {
+		t.Errorf("Worlds mismatch (-expected +actual):\n%s", diff)
+	}
+
+	temporal, ok := data["temporal_rules"].([]any)
+	if !ok || len(temporal) != 1 {
+		t.Fatalf("expected one temporal rule, got: %v", data["temporal_rules"])
+	}
+	rule, ok := temporal[0].(map[string]any)
+	if !ok {
+		t.Fatalf("malformed temporal rule data: %v", temporal[0])
+	}
+	if rule["holds"] != true {
+		t.Fatalf("expected temporal rule to hold")
+	}
+}

--- a/ltl.go
+++ b/ltl.go
@@ -76,18 +76,19 @@ func (m *model) checkBA(b *ba) (bool, *lasso) {
 			continue
 		}
 		for _, n := range scc {
-			if b.accepting[n.s] {
-				prefix := buildPrefix(pre, n)
-				sccSet := make(map[prodNode]bool)
-				for _, pn := range scc {
-					sccSet[pn] = true
-				}
-				loop := findCycle(graph, n, sccSet)
-				if loop == nil {
-					loop = []worldID{n.w}
-				}
-				return false, &lasso{Prefix: prefix, Loop: loop}
+			if !b.accepting[n.s] {
+				continue
 			}
+			prefix := buildPrefix(pre, n)
+			sccSet := make(map[prodNode]bool)
+			for _, pn := range scc {
+				sccSet[pn] = true
+			}
+			loop := findCycle(graph, n, sccSet)
+			if loop == nil {
+				loop = []worldID{n.w}
+			}
+			return false, &lasso{Prefix: prefix, Loop: loop}
 		}
 	}
 	return true, nil

--- a/temporal_rule.go
+++ b/temporal_rule.go
@@ -67,7 +67,7 @@ func WheneverPEventuallyQ(p, q Condition) TemporalRule {
 		trans: map[baState][]baTransition{
 			0: {
 				{to: 1, cond: func(l map[ConditionName]bool) bool { return l[p.Name()] && !l[q.Name()] }},
-				{to: 0, cond: func(l map[ConditionName]bool) bool { return !(l[p.Name()] && !l[q.Name()]) }},
+				{to: 0, cond: func(l map[ConditionName]bool) bool { return !l[p.Name()] || l[q.Name()] }},
 			},
 			1: {
 				{to: 1, cond: func(l map[ConditionName]bool) bool { return !l[q.Name()] }},


### PR DESCRIPTION
## Summary
- simplify Büchi automaton acceptance check to reduce nesting
- apply De Morgan's law in temporal rule condition
- add temporal rule example using WheneverPEventuallyQ with SendTo request/response
- model a realistic order workflow where paid orders eventually ship
- merge temporal rule example model into main.go for consistency with other examples
- rename example and helpers from LTL to temporal rule terminology
- streamline comments in temporal rule example to align with other examples

## Testing
- `golangci-lint run`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c7d6abc66c833186c45d3029f9be6e