### PR TITLE
Refactor temporal rule evidence interface

### DIFF
--- a/example/temporal-rule/main_test.go
+++ b/example/temporal-rule/main_test.go
@@ -53,7 +53,7 @@ func TestTemporalRuleExample(t *testing.T) {
 	if !ok {
 		t.Fatalf("malformed temporal rule data: %v", temporal[0])
 	}
-	if rule["holds"] != true {
+	if rule["satisfied"] != true {
 		t.Fatalf("expected temporal rule to hold")
 	}
 }

--- a/ltl.go
+++ b/ltl.go
@@ -22,11 +22,13 @@ type lasso struct {
 	Loop   []worldID `json:"loop"`
 }
 
+func (*lasso) temporalEvidence() {}
+
 func (m *model) checkLTL() []temporalRuleResult {
 	results := make([]temporalRuleResult, 0, len(m.ltlRules))
 	for _, r := range m.ltlRules {
 		holds, lasso := m.checkBA(r.ba())
-		results = append(results, temporalRuleResult{Rule: r.name(), Holds: holds, Lasso: lasso})
+		results = append(results, temporalRuleResult{Rule: r.name(), Satisfied: holds, Evidence: lasso})
 	}
 	return results
 }

--- a/temporal_rule.go
+++ b/temporal_rule.go
@@ -6,7 +6,7 @@ import "fmt"
 type TemporalRule interface {
 	name() string
 	isTemporalRule() bool
-} 
+}
 
 type ltlRule struct {
 	n string
@@ -17,10 +17,14 @@ func (r ltlRule) name() string         { return r.n }
 func (r ltlRule) isTemporalRule() bool { return true }
 func (r ltlRule) ba() *ba              { return r.b }
 
+type temporalEvidence interface {
+	temporalEvidence()
+}
+
 type temporalRuleResult struct {
-	Rule  string `json:"rule"`
-	Holds bool   `json:"holds"`
-	Lasso *lasso `json:"lasso,omitempty"`
+	Rule      string           `json:"rule"`
+	Satisfied bool             `json:"satisfied"`
+	Evidence  temporalEvidence `json:"evidence,omitempty"`
 }
 
 // WithTemporalRules registers temporal rules for model checking.

--- a/temporal_rule_test.go
+++ b/temporal_rule_test.go
@@ -20,7 +20,7 @@ func TestTemporalRule_EventuallyAlways(t *testing.T) {
 		}
 		_ = m.Solve()
 		res := m.checkLTL()
-		if !res[0].Holds {
+		if !res[0].Satisfied {
 			t.Fatalf("expected rule to hold")
 		}
 	})
@@ -38,10 +38,10 @@ func TestTemporalRule_EventuallyAlways(t *testing.T) {
 		}
 		_ = m.Solve()
 		res := m.checkLTL()
-		if res[0].Holds {
+		if res[0].Satisfied {
 			t.Fatalf("expected rule violation")
 		}
-		if res[0].Lasso == nil {
+		if l, ok := res[0].Evidence.(*lasso); !ok || l == nil {
 			t.Fatalf("expected lasso")
 		}
 	})
@@ -61,7 +61,7 @@ func TestTemporalRule_AlwaysEventually(t *testing.T) {
 		}
 		_ = m.Solve()
 		res := m.checkLTL()
-		if !res[0].Holds {
+		if !res[0].Satisfied {
 			t.Fatalf("expected rule to hold")
 		}
 	})
@@ -79,10 +79,10 @@ func TestTemporalRule_AlwaysEventually(t *testing.T) {
 		}
 		_ = m.Solve()
 		res := m.checkLTL()
-		if res[0].Holds {
+		if res[0].Satisfied {
 			t.Fatalf("expected rule violation")
 		}
-		if res[0].Lasso == nil {
+		if l, ok := res[0].Evidence.(*lasso); !ok || l == nil {
 			t.Fatalf("expected lasso")
 		}
 	})
@@ -103,7 +103,7 @@ func TestTemporalRule_WheneverPEventuallyQ(t *testing.T) {
 		}
 		_ = m.Solve()
 		res := m.checkLTL()
-		if !res[0].Holds {
+		if !res[0].Satisfied {
 			t.Fatalf("expected rule to hold")
 		}
 	})
@@ -122,10 +122,10 @@ func TestTemporalRule_WheneverPEventuallyQ(t *testing.T) {
 		}
 		_ = m.Solve()
 		res := m.checkLTL()
-		if res[0].Holds {
+		if res[0].Satisfied {
 			t.Fatalf("expected rule violation")
 		}
-		if res[0].Lasso == nil {
+		if l, ok := res[0].Evidence.(*lasso); !ok || l == nil {
 			t.Fatalf("expected lasso")
 		}
 	})

--- a/test.go
+++ b/test.go
@@ -40,7 +40,7 @@ func Test(opts ...Option) error {
 	trResults := model.checkLTL()
 	names := make([]string, 0)
 	for _, r := range trResults {
-		if !r.Holds {
+		if !r.Satisfied {
 			names = append(names, r.Rule)
 		}
 	}


### PR DESCRIPTION
## Summary
- rename temporal rule result fields to backend-neutral names and add a temporalEvidence interface
- implement the interface for the existing LTL lasso evidence and update code/tests for the renamed fields

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68cfb76f2668833188e95a076272c776