### PR TITLE
Update protobuf e2e generator tests to use new handler signature

### DIFF
--- a/protobuf/e2e_generator_test.go
+++ b/protobuf/e2e_generator_test.go
@@ -56,7 +56,6 @@ func TestGenerateE2ETest_Golden(t *testing.T) {
 				spec.DefineStates(idleState).SetInitialState(idleState)
 
 				OnProtobufMessage(spec, idleState, "CreateUser",
-					&E2ECreateUserRequest{}, &E2ECreateUserResponse{},
 					func(ctx context.Context, req *E2ECreateUserRequest, svc *E2ETestService) ProtobufResponse[*E2ECreateUserResponse] {
 						return ProtobufSendTo(ctx, svc, &E2ECreateUserResponse{
 							UserID:  "user_123",
@@ -76,7 +75,6 @@ func TestGenerateE2ETest_Golden(t *testing.T) {
 				spec.DefineStates(idleState).SetInitialState(idleState)
 
 				OnProtobufMessage(spec, idleState, "CreateUser",
-					&E2ECreateUserRequest{}, &E2ECreateUserResponse{},
 					func(ctx context.Context, req *E2ECreateUserRequest, svc *E2ETestService) ProtobufResponse[*E2ECreateUserResponse] {
 						return ProtobufSendTo(ctx, svc, &E2ECreateUserResponse{
 							UserID:  "user_" + req.Username,
@@ -96,7 +94,6 @@ func TestGenerateE2ETest_Golden(t *testing.T) {
 				spec.DefineStates(idleState).SetInitialState(idleState)
 
 				OnProtobufMessage(spec, idleState, "CreateUser",
-					&E2ECreateUserRequest{}, &E2ECreateUserResponse{},
 					func(ctx context.Context, req *E2ECreateUserRequest, svc *E2ETestService) ProtobufResponse[*E2ECreateUserResponse] {
 						return ProtobufSendTo(ctx, svc, &E2ECreateUserResponse{
 							UserID:  "user_" + req.Username,
@@ -105,7 +102,6 @@ func TestGenerateE2ETest_Golden(t *testing.T) {
 					})
 
 				OnProtobufMessage(spec, idleState, "GetUser",
-					&E2EGetUserRequest{}, &E2EGetUserResponse{},
 					func(ctx context.Context, req *E2EGetUserRequest, svc *E2ETestService) ProtobufResponse[*E2EGetUserResponse] {
 						return ProtobufSendTo(ctx, svc, &E2EGetUserResponse{
 							Username: "testuser",


### PR DESCRIPTION
## Summary
- update the protobuf E2E generator tests to call OnProtobufMessage with the new handler-only signature

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691007882768833193a51d7cb30be4fb)