### PR TITLE
Remove WithConditions API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,8 @@ func main() {
 
     err = goat.Test(
         goat.WithStateMachines(sm),
-        goat.WithConditions(cond),
-        goat.WithInvariants(cond),
-        goat.WithTemporalRules(
+        goat.WithRules(
+            goat.Always(cond),
             goat.WheneverPEventuallyQ(cond, cond),
             goat.EventuallyAlways(cond),
             goat.AlwaysEventually(cond),
@@ -85,9 +84,7 @@ func main() {
 - **`Test()`** - Run model checking with invariant verification
 - **`Debug()`** - Output detailed JSON results for debugging
 - **`WithStateMachines()`** - Configure which state machines to test
-- **`WithConditions()`** - Register named conditions
-- **`WithInvariants()`** - Configure conditions to check as invariants
-- **`WithTemporalRules()`** - Register temporal rules to verify temporal properties
+- **`WithRules()`** - Register rules created with helpers like `Always` and `WheneverPEventuallyQ` in one place
 
 ## Examples
 

--- a/condition.go
+++ b/condition.go
@@ -33,7 +33,7 @@ func (f conditionFunc) Evaluate(w world) bool { return f.fn(w) }
 //   - name: The name of this condition
 //   - b: The boolean value that this condition will always return
 //
-// Returns a Condition that can be used with Test() or WithInvariants().
+// Returns a Condition that can be used with Test() (for example via WithRules(Always(...))).
 //
 // Example:
 //
@@ -52,7 +52,7 @@ func BoolCondition(name string, b bool) Condition {
 //   - sm: The state machine instance to create a condition for
 //   - check: A predicate function that returns true if the condition holds
 //
-// Returns a Condition that can be used with Test() or WithInvariants().
+// Returns a Condition that can be used with Test() (for example via WithRules(Always(...))).
 //
 // Example:
 //
@@ -132,7 +132,7 @@ func GetMachine[T AbstractStateMachine](m Machines, sm T) (T, bool) {
 //   - checkFunc: Predicate that inspects one or more state machines
 //   - sms: State machines referenced by the condition
 //
-// Returns a Condition that can be used with Test() or WithInvariants().
+// Returns a Condition that can be used with Test() (for example via WithRules(Always(...))).
 //
 // Example:
 //
@@ -171,7 +171,7 @@ func NewMultiCondition(name string, checkFunc func(Machines) bool, sms ...Abstra
 //   - sm1, sm2: The state machines to reference
 //   - check: A predicate function that returns true if the condition holds
 //
-// Returns a Condition that can be used with Test() or WithInvariants().
+// Returns a Condition that can be used with Test() (for example via WithRules(Always(...))).
 //
 // Example:
 //
@@ -199,7 +199,7 @@ func NewCondition2[T1, T2 AbstractStateMachine](name string, sm1 T1, sm2 T2, che
 //   - sm1, sm2, sm3: The state machines to reference
 //   - check: A predicate function that returns true if the condition holds
 //
-// Returns a Condition that can be used with Test() or WithInvariants().
+// Returns a Condition that can be used with Test() (for example via WithRules(Always(...))).
 //
 // Example:
 //

--- a/example/client-server/main.go
+++ b/example/client-server/main.go
@@ -168,8 +168,7 @@ func createClientServerModel() []goat.Option {
 
 	opts := []goat.Option{
 		goat.WithStateMachines(server, client),
-		goat.WithConditions(cond),
-		goat.WithInvariants(cond),
+		goat.WithRules(goat.Always(cond)),
 	}
 
 	return opts

--- a/example/meeting-room-reservation/with-exclusion/main.go
+++ b/example/meeting-room-reservation/with-exclusion/main.go
@@ -323,8 +323,7 @@ func createMeetingRoomWithExclusionModel() []goat.Option {
 
 	opts := []goat.Option{
 		goat.WithStateMachines(server1, server2, db, client1, client2),
-		goat.WithConditions(cond),
-		goat.WithInvariants(cond),
+		goat.WithRules(goat.Always(cond)),
 	}
 
 	return opts

--- a/example/meeting-room-reservation/without-exclusion/main.go
+++ b/example/meeting-room-reservation/without-exclusion/main.go
@@ -292,8 +292,7 @@ func createMeetingRoomWithoutExclusionModel() []goat.Option {
 
 	opts := []goat.Option{
 		goat.WithStateMachines(server1, server2, db, client1, client2),
-		goat.WithConditions(cond),
-		goat.WithInvariants(cond),
+		goat.WithRules(goat.Always(cond)),
 	}
 
 	return opts

--- a/example/simple-transition/main.go
+++ b/example/simple-transition/main.go
@@ -64,8 +64,7 @@ func createSimpleTransitionModel() []goat.Option {
 
 	opts := []goat.Option{
 		goat.WithStateMachines(sm),
-		goat.WithConditions(cond),
-		goat.WithInvariants(cond),
+		goat.WithRules(goat.Always(cond)),
 	}
 
 	return opts

--- a/example/temporal-rule-violation/main.go
+++ b/example/temporal-rule-violation/main.go
@@ -91,8 +91,7 @@ func createTemporalRuleViolationModel() []goat.Option {
 
 	opts := []goat.Option{
 		goat.WithStateMachines(shipper, order),
-		goat.WithConditions(inPaid, inShipped),
-		goat.WithTemporalRules(rule),
+		goat.WithRules(rule),
 	}
 
 	return opts

--- a/example/temporal-rule/main.go
+++ b/example/temporal-rule/main.go
@@ -91,8 +91,7 @@ func createTemporalRuleModel() []goat.Option {
 
 	opts := []goat.Option{
 		goat.WithStateMachines(shipper, order),
-		goat.WithConditions(inPaid, inShipped),
-		goat.WithTemporalRules(rule),
+		goat.WithRules(rule),
 	}
 
 	return opts

--- a/model.go
+++ b/model.go
@@ -259,14 +259,13 @@ type options struct {
 // state machines, conditions, invariants, and other testing parameters.
 //
 // Use the provided helper functions like WithStateMachines(),
-// WithConditions(), and WithInvariants() to create options.
+// WithRules() to create options.
 //
 // Example:
 //
 //	goat.Test(
 //	    goat.WithStateMachines(sm1, sm2),
-//	    goat.WithConditions(cond1),
-//	    goat.WithInvariants(cond1),
+//	    goat.WithRules(goat.Always(cond1)),
 //	)
 type Option interface {
 	apply(*options)

--- a/model_test.go
+++ b/model_test.go
@@ -68,8 +68,7 @@ func TestModel_Solve(t *testing.T) {
 				inv := BoolCondition("inv", false) // Always false condition
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				return m
 			},
@@ -179,8 +178,7 @@ func TestModel_evaluateInvariants(t *testing.T) {
 				inv := BoolCondition("pass", true)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				w := initialWorld(sm)
 				return m, w
@@ -194,8 +192,7 @@ func TestModel_evaluateInvariants(t *testing.T) {
 				inv := BoolCondition("fail", false)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				w := initialWorld(sm)
 				return m, w
@@ -211,8 +208,7 @@ func TestModel_evaluateInvariants(t *testing.T) {
 				inv3 := BoolCondition("i3", true)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv1, inv2, inv3),
-					WithInvariants(inv1, inv2, inv3),
+					WithRules(Always(inv1), Always(inv2), Always(inv3)),
 				)
 				w := initialWorld(sm)
 				return m, w

--- a/output_test.go
+++ b/output_test.go
@@ -44,8 +44,7 @@ testStateMachine << entryEvent;" ];
 				inv := BoolCondition("inv", false)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				_ = m.Solve()
 				return m
@@ -138,8 +137,7 @@ func TestModel_writeInvariantViolations(t *testing.T) {
 				inv := BoolCondition("pass", true)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				_ = m.Solve()
 				return m
@@ -153,8 +151,7 @@ func TestModel_writeInvariantViolations(t *testing.T) {
 				inv := BoolCondition("fail", false)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				_ = m.Solve()
 				return m
@@ -189,8 +186,7 @@ func TestModel_writeTemporalViolations(t *testing.T) {
 	cFalse := BoolCondition("c", false)
 	m, err := newModel(
 		WithStateMachines(sm),
-		WithConditions(cFalse),
-		WithTemporalRules(EventuallyAlways(cFalse)),
+		WithRules(EventuallyAlways(cFalse)),
 	)
 	if err != nil {
 		t.Fatalf("newModel error: %v", err)
@@ -293,8 +289,7 @@ func TestModel_collectInvariantViolations(t *testing.T) {
 				inv := BoolCondition("pass", true)
 				m, err := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				if err != nil {
 					panic(err)
@@ -311,8 +306,7 @@ func TestModel_collectInvariantViolations(t *testing.T) {
 				inv := BoolCondition("fail", false)
 				m, err := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				if err != nil {
 					panic(err)
@@ -360,8 +354,7 @@ func TestModel_collectInvariantViolations(t *testing.T) {
 
 				m, err := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				if err != nil {
 					panic(err)
@@ -631,8 +624,7 @@ func TestModel_summarize(t *testing.T) {
 				inv := BoolCondition("pass", true)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				_ = m.Solve()
 				return m
@@ -650,8 +642,7 @@ func TestModel_summarize(t *testing.T) {
 				inv := BoolCondition("fail", false)
 				m, _ := newModel(
 					WithStateMachines(sm),
-					WithConditions(inv),
-					WithInvariants(inv),
+					WithRules(Always(inv)),
 				)
 				_ = m.Solve()
 				return m

--- a/protobuf/e2e_builder.go
+++ b/protobuf/e2e_builder.go
@@ -3,6 +3,7 @@ package protobuf
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/goatx/goat"
 )
@@ -104,4 +105,28 @@ func executeHandler(spec AbstractProtobufServiceSpec, methodName string, input A
 	eventResults := response.MethodByName("GetEvent").Call(nil)
 
 	return eventResults[0].Interface().(AbstractProtobufMessage), nil
+}
+
+// toSnakeCase converts a PascalCase or camelCase string to snake_case.
+func toSnakeCase(name string) string {
+	var result strings.Builder
+
+	for i, r := range name {
+		if r >= 'A' && r <= 'Z' {
+			if i > 0 {
+				prevChar := rune(name[i-1])
+				if prevChar >= 'a' && prevChar <= 'z' {
+					result.WriteRune('_')
+				} else if i < len(name)-1 {
+					nextChar := rune(name[i+1])
+					if nextChar >= 'a' && nextChar <= 'z' {
+						result.WriteRune('_')
+					}
+				}
+			}
+		}
+		result.WriteRune(r)
+	}
+
+	return strings.ToLower(result.String())
 }

--- a/protobuf/writer.go
+++ b/protobuf/writer.go
@@ -92,7 +92,7 @@ func (w *fileWriter) writeMessage(builder *strings.Builder, message *protoMessag
 			fieldType = "repeated " + fieldType
 		}
 
-		fieldName := toSnakeCase(field.Name)
+		fieldName := w.toSnakeCase(field.Name)
 		builder.WriteString("  ")
 		builder.WriteString(fieldType)
 		builder.WriteString(" ")
@@ -123,9 +123,7 @@ func (*fileWriter) writeService(builder *strings.Builder, service *protoService)
 	builder.WriteString("}")
 }
 
-// toSnakeCase converts a PascalCase or camelCase string to snake_case.
-// Handles cases like HTTPRequest -> http_request and userID -> user_id.
-func toSnakeCase(name string) string {
+func (*fileWriter) toSnakeCase(name string) string {
 	var result strings.Builder
 
 	for i, r := range name {

--- a/protobuf/writer_test.go
+++ b/protobuf/writer_test.go
@@ -162,7 +162,7 @@ message User {
 	}
 }
 
-func Test_toSnakeCase(t *testing.T) {
+func TestFileWriter_toSnakeCase(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -202,7 +202,8 @@ func Test_toSnakeCase(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := toSnakeCase(tt.input)
+			w := &fileWriter{}
+			got := w.toSnakeCase(tt.input)
 
 			if got != tt.want {
 				t.Errorf("toSnakeCase(%q) = %q, want %q", tt.input, got, tt.want)

--- a/rule.go
+++ b/rule.go
@@ -1,0 +1,76 @@
+package goat
+
+// Rule represents a property that can be enforced during model checking.
+// Rules register additional checks that run while exploring the state space.
+type Rule interface {
+	apply(*options)
+}
+
+type ruleFunc func(*options)
+
+func (f ruleFunc) apply(o *options) {
+	f(o)
+}
+
+// WithRules returns an Option that registers the provided rules during model checking.
+//
+// Parameters:
+//   - rs: Rules created with helpers such as Always or WheneverPEventuallyQ
+//
+// Returns an Option that can be supplied to Test.
+//
+// Example:
+//
+//	err := goat.Test(
+//		goat.WithStateMachines(node),
+//		goat.WithRules(
+//			goat.Always(consistency),
+//			goat.WheneverPEventuallyQ(requested, responded),
+//		),
+//	)
+func WithRules(rs ...Rule) Option {
+	return optionFunc(func(o *options) {
+		for _, r := range rs {
+			if r == nil {
+				continue
+			}
+			r.apply(o)
+		}
+	})
+}
+
+// Always returns a rule that ensures c holds in every explored world.
+//
+// Parameters:
+//   - c: Condition that must remain true in all explored states
+//
+// Returns a Rule that can be supplied to WithRules.
+//
+// Example:
+//
+//	err := goat.Test(
+//		goat.WithStateMachines(node),
+//		goat.WithRules(
+//			goat.Always(healthy),
+//		),
+//	)
+func Always(c Condition) Rule {
+	return ruleFunc(func(o *options) {
+		registerCondition(o, c)
+		o.invariants = append(o.invariants, c.Name())
+	})
+}
+
+func registerCondition(o *options, c Condition) {
+	if c == nil {
+		return
+	}
+	if o.conds == nil {
+		o.conds = make(map[ConditionName]Condition)
+	}
+	o.conds[c.Name()] = c
+}
+
+func registerTemporalRule(o *options, rule ltlRule) {
+	o.ltlRules = append(o.ltlRules, rule)
+}

--- a/temporal_rule.go
+++ b/temporal_rule.go
@@ -2,20 +2,13 @@ package goat
 
 import "fmt"
 
-// TemporalRule represents a temporal property specified
-type TemporalRule interface {
-	name() string
-	isTemporalRule() bool
-}
-
 type ltlRule struct {
 	n string
 	b *ba
 }
 
-func (r ltlRule) name() string       { return r.n }
-func (ltlRule) isTemporalRule() bool { return true }
-func (r ltlRule) ba() *ba            { return r.b }
+func (r ltlRule) name() string { return r.n }
+func (r ltlRule) ba() *ba      { return r.b }
 
 type temporalEvidence interface {
 	temporalEvidence()
@@ -27,49 +20,23 @@ type temporalRuleResult struct {
 	Evidence  temporalEvidence `json:"evidence,omitempty"`
 }
 
-// WithTemporalRules registers temporal rules for model checking.
-//
-// Parameters:
-//   - rs: The temporal rules to enforce during verification
-//
-// Returns an Option that can be passed to Test or Debug.
-//
-// Example:
-//
-//	err := goat.Test(
-//	    goat.WithStateMachines(sm),
-//	    goat.WithTemporalRules(goat.EventuallyAlways(cond)),
-//	)
-func WithTemporalRules(rs ...TemporalRule) Option {
-	return optionFunc(func(o *options) {
-		for _, r := range rs {
-			ltlRule, ok := r.(ltlRule)
-			if !ok {
-				panic(fmt.Sprintf("temporal rule %T must be constructed using helper functions like WheneverPEventuallyQ or EventuallyAlways", r))
-			}
-			o.ltlRules = append(o.ltlRules, ltlRule)
-		}
-	})
-}
-
 // WheneverPEventuallyQ returns a rule enforcing that whenever p holds, q eventually holds.
 //
 // Parameters:
 //   - p: Condition that triggers the obligation
 //   - q: Condition that must eventually become true
 //
-// Returns a TemporalRule that can be registered with WithTemporalRules.
+// Returns a Rule that can be registered with WithRules.
 //
 // Example:
 //
 //	err := goat.Test(
 //		goat.WithStateMachines(primary, replica),
-//		goat.WithConditions(write, replicated),
-//		goat.WithTemporalRules(
+//		goat.WithRules(
 //			goat.WheneverPEventuallyQ(write, replicated),
 //		),
 //	)
-func WheneverPEventuallyQ(p, q Condition) TemporalRule {
+func WheneverPEventuallyQ(p, q Condition) Rule {
 	name := fmt.Sprintf("whenever %s eventually %s", p.Name(), q.Name())
 	b := &ba{
 		initial:   0,
@@ -88,7 +55,12 @@ func WheneverPEventuallyQ(p, q Condition) TemporalRule {
 			},
 		},
 	}
-	return ltlRule{n: name, b: b}
+
+	return ruleFunc(func(o *options) {
+		registerCondition(o, p)
+		registerCondition(o, q)
+		registerTemporalRule(o, ltlRule{n: name, b: b})
+	})
 }
 
 // EventuallyAlways returns a rule enforcing that c eventually holds forever.
@@ -96,18 +68,17 @@ func WheneverPEventuallyQ(p, q Condition) TemporalRule {
 // Parameters:
 //   - c: Condition that must eventually remain true
 //
-// Returns a TemporalRule that can be registered with WithTemporalRules.
+// Returns a Rule that can be registered with WithRules.
 //
 // Example:
 //
 //	err := goat.Test(
-//	    goat.WithStateMachines(nodes...),
-//	    goat.WithConditions(stable),
-//	    goat.WithTemporalRules(
+//		goat.WithStateMachines(nodes...),
+//		goat.WithRules(
 //			goat.EventuallyAlways(stable),
 //		),
 //	)
-func EventuallyAlways(c Condition) TemporalRule {
+func EventuallyAlways(c Condition) Rule {
 	name := fmt.Sprintf("eventually always %s", c.Name())
 	b := &ba{
 		initial:   0,
@@ -123,7 +94,11 @@ func EventuallyAlways(c Condition) TemporalRule {
 			},
 		},
 	}
-	return ltlRule{n: name, b: b}
+
+	return ruleFunc(func(o *options) {
+		registerCondition(o, c)
+		registerTemporalRule(o, ltlRule{n: name, b: b})
+	})
 }
 
 // AlwaysEventually returns a rule enforcing that c holds infinitely often.
@@ -131,18 +106,17 @@ func EventuallyAlways(c Condition) TemporalRule {
 // Parameters:
 //   - c: Condition that must recur indefinitely
 //
-// Returns a TemporalRule that can be registered with WithTemporalRules.
+// Returns a Rule that can be registered with WithRules.
 //
 // Example:
 //
 //	err := goat.Test(
-//	    goat.WithStateMachines(node),
-//	    goat.WithConditions(heartbeat),
-//	    goat.WithTemporalRules(
+//		goat.WithStateMachines(node),
+//		goat.WithRules(
 //			goat.AlwaysEventually(heartbeat),
 //		),
 //	)
-func AlwaysEventually(c Condition) TemporalRule {
+func AlwaysEventually(c Condition) Rule {
 	name := fmt.Sprintf("always eventually %s", c.Name())
 	b := &ba{
 		initial:   0,
@@ -161,5 +135,9 @@ func AlwaysEventually(c Condition) TemporalRule {
 			},
 		},
 	}
-	return ltlRule{n: name, b: b}
+
+	return ruleFunc(func(o *options) {
+		registerCondition(o, c)
+		registerTemporalRule(o, ltlRule{n: name, b: b})
+	})
 }

--- a/temporal_rule_test.go
+++ b/temporal_rule_test.go
@@ -8,8 +8,7 @@ func TestEventuallyAlways(t *testing.T) {
 		cTrue := BoolCondition("c", true)
 		m, err := newModel(
 			WithStateMachines(sm),
-			WithConditions(cTrue),
-			WithTemporalRules(EventuallyAlways(cTrue)),
+			WithRules(EventuallyAlways(cTrue)),
 		)
 		if err != nil {
 			t.Fatalf("newModel error: %v", err)
@@ -26,8 +25,7 @@ func TestEventuallyAlways(t *testing.T) {
 		cFalse := BoolCondition("cF", false)
 		m, err := newModel(
 			WithStateMachines(sm),
-			WithConditions(cFalse),
-			WithTemporalRules(EventuallyAlways(cFalse)),
+			WithRules(EventuallyAlways(cFalse)),
 		)
 		if err != nil {
 			t.Fatalf("newModel error: %v", err)
@@ -49,8 +47,7 @@ func TestAlwaysEventually(t *testing.T) {
 		cTrue := BoolCondition("c", true)
 		m, err := newModel(
 			WithStateMachines(sm),
-			WithConditions(cTrue),
-			WithTemporalRules(AlwaysEventually(cTrue)),
+			WithRules(AlwaysEventually(cTrue)),
 		)
 		if err != nil {
 			t.Fatalf("newModel error: %v", err)
@@ -67,8 +64,7 @@ func TestAlwaysEventually(t *testing.T) {
 		cFalse := BoolCondition("cF", false)
 		m, err := newModel(
 			WithStateMachines(sm),
-			WithConditions(cFalse),
-			WithTemporalRules(AlwaysEventually(cFalse)),
+			WithRules(AlwaysEventually(cFalse)),
 		)
 		if err != nil {
 			t.Fatalf("newModel error: %v", err)
@@ -91,8 +87,7 @@ func TestWheneverPEventuallyQ(t *testing.T) {
 		qTrue := BoolCondition("q", true)
 		m, err := newModel(
 			WithStateMachines(sm),
-			WithConditions(pTrue, qTrue),
-			WithTemporalRules(WheneverPEventuallyQ(pTrue, qTrue)),
+			WithRules(WheneverPEventuallyQ(pTrue, qTrue)),
 		)
 		if err != nil {
 			t.Fatalf("newModel error: %v", err)
@@ -110,8 +105,7 @@ func TestWheneverPEventuallyQ(t *testing.T) {
 		qFalse := BoolCondition("q", false)
 		m, err := newModel(
 			WithStateMachines(sm),
-			WithConditions(pTrue, qFalse),
-			WithTemporalRules(WheneverPEventuallyQ(pTrue, qFalse)),
+			WithRules(WheneverPEventuallyQ(pTrue, qFalse)),
 		)
 		if err != nil {
 			t.Fatalf("newModel error: %v", err)

--- a/test.go
+++ b/test.go
@@ -21,8 +21,7 @@ import (
 //
 //	err := goat.Test(
 //	    goat.WithStateMachines(serverSM, clientSM),
-//	    goat.WithConditions(cond),
-//	    goat.WithInvariants(cond),
+//	    goat.WithRules(goat.Always(cond)),
 //	)
 func Test(opts ...Option) error {
 	model, err := newModel(opts...)
@@ -74,43 +73,6 @@ func WithStateMachines(sms ...AbstractStateMachine) Option {
 	})
 }
 
-// WithConditions registers conditions that can be referenced by invariants or other checks.
-//
-// Parameters:
-//   - cs: The conditions to register
-//
-// Returns an Option that can be passed to Test() or Debug().
-func WithConditions(cs ...Condition) Option {
-	return optionFunc(func(o *options) {
-		if o.conds == nil {
-			o.conds = make(map[ConditionName]Condition)
-		}
-		for _, c := range cs {
-			o.conds[c.Name()] = c
-		}
-	})
-}
-
-// WithInvariants configures the test with the specified conditions as invariants.
-// These conditions will be checked during model exploration to detect
-// violations of system properties.
-//
-// Parameters:
-//   - cs: The conditions to check during testing
-//
-// Returns an Option that can be passed to Test() or Debug().
-//
-// Example:
-//
-//	goat.WithInvariants(conditionA, conditionB)
-func WithInvariants(cs ...Condition) Option {
-	return optionFunc(func(o *options) {
-		for _, c := range cs {
-			o.invariants = append(o.invariants, c.Name())
-		}
-	})
-}
-
 // Debug performs model checking and outputs detailed JSON results.
 // Unlike Test(), this function provides comprehensive debugging information
 // including all explored worlds and their states in JSON format.
@@ -124,7 +86,7 @@ func WithInvariants(cs ...Condition) Option {
 // Example:
 //
 //	var buf bytes.Buffer
-//	err := goat.Debug(&buf, goat.WithStateMachines(sm), goat.WithConditions(cond), goat.WithInvariants(cond))
+//	err := goat.Debug(&buf, goat.WithStateMachines(sm), goat.WithRules(goat.Always(cond)))
 //	fmt.Println(buf.String()) // JSON output
 func Debug(w io.Writer, opts ...Option) error {
 	model, err := newModel(opts...)
@@ -173,7 +135,7 @@ func Debug(w io.Writer, opts ...Option) error {
 //		    return err
 //		}
 //		defer file.Close()
-//	     err = goat.WriteDot(file, goat.WithStateMachines(sm), goat.WithConditions(cond), goat.WithInvariants(cond))
+//	     err = goat.WriteDot(file, goat.WithStateMachines(sm), goat.WithRules(goat.Always(cond)))
 func WriteDot(w io.Writer, opts ...Option) error {
 	model, err := newModel(opts...)
 	if err != nil {


### PR DESCRIPTION
## Summary
- revert the README, examples, and core model APIs to use the existing WithRules helper instead of the newly added WithConditions/WithInvariants options
- restore the original rule and temporal rule helpers and tests that were modified when the extra options were added
- keep the protobuf E2E generator functional by adding a local toSnakeCase helper so the builder no longer depends on the reverted writer changes

## Testing
- go test ./...


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691009444e60833192559dc1cebcbaa9)