### PR TITLE
feat: separate main test and service test generation

### DIFF
--- a/environment.go
+++ b/environment.go
@@ -145,3 +145,27 @@ func Halt(ctx context.Context, target AbstractStateMachine) {
 	env := getEnvFromContext(ctx)
 	env.enqueueEvent(target, &haltEvent{})
 }
+
+// NewHandlerContext creates a context with a minimal environment for executing handlers.
+// This is used when you need to execute handlers outside of the normal model checking flow.
+//
+// Parameters:
+//   - sm: The state machine instance to include in the context
+//
+// Returns a context that can be used with SendTo, Goto, and other handler functions.
+//
+// Example:
+//
+//	instance, _ := spec.NewInstance()
+//	ctx := goat.NewHandlerContext(instance)
+//	response := handler(ctx, input, instance)
+func NewHandlerContext(sm AbstractStateMachine) context.Context {
+	env := environment{
+		machines: make(map[string]AbstractStateMachine),
+		queue:    make(map[string][]AbstractEvent),
+	}
+	if sm != nil {
+		env.machines[sm.id()] = sm
+	}
+	return withEnvAndSM(&env, sm)
+}

--- a/internal/e2egen/types.go
+++ b/internal/e2egen/types.go
@@ -1,0 +1,25 @@
+package e2egen
+
+type TestSuite struct {
+	TestPackage string
+	Groups      []TestGroup
+}
+
+type TestGroup struct {
+	Name          string
+	SchemaPackage string
+	Operations    []Operation
+}
+
+type Operation struct {
+	Name      string
+	TestCases []TestCase
+}
+
+type TestCase struct {
+	Name       string
+	InputType  string
+	Input      map[string]any
+	OutputType string
+	Output     map[string]any
+}

--- a/internal/strcase/strcase.go
+++ b/internal/strcase/strcase.go
@@ -1,6 +1,9 @@
 package strcase
 
-import "unicode"
+import (
+	"strings"
+	"unicode"
+)
 
 func ToCamelCase(name string) string {
 	if name == "" {
@@ -29,10 +32,10 @@ func ToSnakeCase(s string) string {
 				prev := runes[i-1]
 				nextLower := false
 				if i < len(runes)-1 {
-					nextLower = unicode.IsLower(runes[i+1]) || unicode.IsDigit(runes[i+1])
+					nextLower = unicode.IsLower(runes[i+1])
 				}
 
-				if unicode.IsLower(prev) || unicode.IsDigit(prev) || nextLower {
+				if unicode.IsLower(prev) || nextLower {
 					result = append(result, '_')
 				}
 			}
@@ -43,4 +46,17 @@ func ToSnakeCase(s string) string {
 	}
 
 	return string(result)
+}
+
+func ToProtobufFieldName(s string) string {
+	snake := ToSnakeCase(s)
+	parts := strings.Split(snake, "_")
+	var result strings.Builder
+	for _, part := range parts {
+		if part != "" {
+			result.WriteString(strings.ToUpper(string(part[0])))
+			result.WriteString(part[1:])
+		}
+	}
+	return result.String()
 }

--- a/internal/strcase/strcase_test.go
+++ b/internal/strcase/strcase_test.go
@@ -55,3 +55,29 @@ func TestToSnakeCase(t *testing.T) {
 		})
 	}
 }
+
+func TestToProtobufFieldName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"UserID", "UserID", "UserId"},
+		{"HTTPServer", "HTTPServer", "HttpServer"},
+		{"Simple", "Username", "Username"},
+		{"URLValue", "URLValue", "UrlValue"},
+		{"Empty", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := ToProtobufFieldName(tt.input); got != tt.want {
+				t.Fatalf("ToProtobufFieldName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/typeutil/typeutil.go
+++ b/internal/typeutil/typeutil.go
@@ -2,13 +2,31 @@ package typeutil
 
 import (
 	"reflect"
+	"strings"
 )
+
+func IsEventType(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.Kind() == reflect.Struct &&
+		strings.HasPrefix(t.Name(), "Event[") &&
+		t.PkgPath() == "github.com/goatx/goat"
+}
 
 func Name(v any) string {
 	t := reflect.TypeOf(v)
 	if t == nil {
 		return ""
 	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	return t.Name()
+}
+
+func NameOf[T any]() string {
+	t := reflect.TypeFor[T]()
 	if t.Kind() == reflect.Ptr {
 		t = t.Elem()
 	}

--- a/internal/typeutil/typeutil_test.go
+++ b/internal/typeutil/typeutil_test.go
@@ -1,7 +1,10 @@
 package typeutil
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/goatx/goat"
 )
 
 type sampleStruct struct{}
@@ -30,6 +33,74 @@ func TestName(t *testing.T) {
 
 			if got := Name(tt.input); got != tt.want {
 				t.Fatalf("Name(%v) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNameOf(t *testing.T) {
+	t.Parallel()
+
+	if got := NameOf[sampleStruct](); got != "sampleStruct" {
+		t.Fatalf("NameOf[sampleStruct]() = %q, want %q", got, "sampleStruct")
+	}
+	if got := NameOf[*sampleStruct](); got != "sampleStruct" {
+		t.Fatalf("NameOf[*sampleStruct]() = %q, want %q", got, "sampleStruct")
+	}
+}
+
+type testStateMachine struct {
+	goat.StateMachine
+}
+type otherEvent struct{}
+
+func TestIsEventType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		typ  reflect.Type
+		want bool
+	}{
+		{
+			name: "StructValueFromGoatPackage",
+			typ:  reflect.TypeOf(goat.Event[*testStateMachine, *testStateMachine]{}),
+			want: true,
+		},
+		{
+			name: "PointerValueFromGoatPackage",
+			typ:  reflect.TypeOf(&goat.Event[*testStateMachine, *testStateMachine]{}),
+			want: true,
+		},
+		{
+			name: "PrefixMatchesButDifferentPackage",
+			typ:  reflect.TypeOf(otherEvent{}),
+			want: false,
+		},
+		{
+			name: "StructInGoatPackageWithoutEventPrefix",
+			typ:  reflect.TypeOf(goat.State{}),
+			want: false,
+		},
+		{
+			name: "NonStructType",
+			typ:  reflect.TypeOf(42),
+			want: false,
+		},
+		{
+			name: "PointerToNonStruct",
+			typ:  reflect.TypeOf(new(int)),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := IsEventType(tt.typ); got != tt.want {
+				t.Fatalf("IsEventType(%v) = %v, want %v", tt.typ, got, tt.want)
 			}
 		})
 	}

--- a/protobuf/analyzer.go
+++ b/protobuf/analyzer.go
@@ -43,8 +43,8 @@ func (a *typeAnalyzer) analyzeSpecs(specs ...AbstractServiceSpec) *definitions {
 		service := a.analyzeServiceSpecInterface(spec)
 		definitions.Services = append(definitions.Services, service)
 
-		messages := make([]*message, 0, len(spec.GetMessages()))
-		for _, message := range spec.GetMessages() {
+		messages := make([]*message, 0, len(spec.getMessages()))
+		for _, message := range spec.getMessages() {
 			messages = append(messages, message)
 		}
 		sort.Slice(messages, func(i, j int) bool {
@@ -58,7 +58,7 @@ func (a *typeAnalyzer) analyzeSpecs(specs ...AbstractServiceSpec) *definitions {
 }
 
 func (*typeAnalyzer) analyzeServiceSpecInterface(spec AbstractServiceSpec) *service {
-	rpcMethods := spec.GetRPCMethods()
+	rpcMethods := spec.getRPCMethods()
 
 	serviceName := ""
 	if len(rpcMethods) > 0 {

--- a/protobuf/api_test.go
+++ b/protobuf/api_test.go
@@ -42,14 +42,14 @@ func TestOnMessage(t *testing.T) {
 			state := &TestIdleState{}
 			spec.DefineStates(state).SetInitialState(state)
 
-			initialMethodCount := len(spec.GetRPCMethods())
+			initialMethodCount := len(spec.getRPCMethods())
 
 			OnMessage(spec, state, tt.methodName,
 				func(ctx context.Context, event *TestRequest1, sm *TestService1) Response[*TestResponse1] {
 					return SendTo(ctx, sm, &TestResponse1{Result: "test"})
 				})
 
-			methods := spec.GetRPCMethods()
+			methods := spec.getRPCMethods()
 			if len(methods) != initialMethodCount+1 {
 				t.Fatalf("expected %d method(s), got %d", initialMethodCount+1, len(methods))
 			}
@@ -62,7 +62,7 @@ func TestOnMessage(t *testing.T) {
 				t.Fatal("StateMachineSpec should not be nil after OnMessage call")
 			}
 
-			if len(spec.GetRPCMethods()) == 0 {
+			if len(spec.getRPCMethods()) == 0 {
 				t.Error("RPC methods should be registered after OnMessage call")
 			}
 		})

--- a/protobuf/e2e_builder.go
+++ b/protobuf/e2e_builder.go
@@ -1,0 +1,104 @@
+package protobuf
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/goatx/goat"
+	"github.com/goatx/goat/internal/e2egen"
+	"github.com/goatx/goat/internal/strcase"
+	"github.com/goatx/goat/internal/typeutil"
+)
+
+func buildTestSuite(opts E2ETestOptions) (e2egen.TestSuite, error) {
+	suite := e2egen.TestSuite{
+		TestPackage: opts.PackageName,
+	}
+
+	for _, svc := range opts.Services {
+		serviceName := svc.Spec.getServiceName()
+		if svc.ServicePackage == "" {
+			return e2egen.TestSuite{}, fmt.Errorf("service package is required")
+		}
+
+		methods := make([]e2egen.Operation, 0, len(svc.Methods))
+
+		for _, method := range svc.Methods {
+			cases := make([]e2egen.TestCase, 0, len(method.Inputs))
+
+			for ii, input := range method.Inputs {
+				output, err := executeHandler(svc.Spec, method.MethodName, input)
+				if err != nil {
+					return e2egen.TestSuite{}, fmt.Errorf("service (%s) method (%s) input (%d): failed to execute handler: %w",
+						serviceName, method.MethodName, ii, err)
+				}
+
+				inputData := serializeMessage(input)
+				outputData := serializeMessage(output)
+
+				cases = append(cases, e2egen.TestCase{
+					Name:       fmt.Sprintf("case_%d", ii),
+					InputType:  typeutil.Name(input),
+					Input:      inputData,
+					OutputType: typeutil.Name(output),
+					Output:     outputData,
+				})
+			}
+
+			methods = append(methods, e2egen.Operation{
+				Name:      method.MethodName,
+				TestCases: cases,
+			})
+		}
+
+		suite.Groups = append(suite.Groups, e2egen.TestGroup{
+			Name:          serviceName,
+			SchemaPackage: svc.ServicePackage,
+			Operations:    methods,
+		})
+	}
+
+	return suite, nil
+}
+
+func executeHandler(spec AbstractServiceSpec, methodName string, input AbstractMessage) (AbstractMessage, error) {
+	handlers := spec.getHandlers()
+	handler, ok := handlers[methodName]
+	if !ok {
+		return nil, fmt.Errorf("no handler found for method %s", methodName)
+	}
+
+	instance, err := spec.newInstance()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create state machine instance: %w", err)
+	}
+
+	ctx := goat.NewHandlerContext(instance)
+	return handler(ctx, input, instance), nil
+}
+
+func serializeMessage(msg AbstractMessage) map[string]any {
+	data := make(map[string]any)
+
+	val := reflect.ValueOf(msg)
+	if val.Kind() == reflect.Ptr {
+		val = val.Elem()
+	}
+	typ := val.Type()
+
+	for i := 0; i < val.NumField(); i++ {
+		field := typ.Field(i)
+		fieldVal := val.Field(i)
+
+		if !field.IsExported() || field.Anonymous || field.Name == "_" {
+			continue
+		}
+		if typeutil.IsEventType(field.Type) || isMessageType(field.Type) {
+			continue
+		}
+
+		data[strcase.ToProtobufFieldName(field.Name)] = fieldVal.Interface()
+	}
+
+	return data
+}

--- a/protobuf/e2e_builder_test.go
+++ b/protobuf/e2e_builder_test.go
@@ -1,0 +1,163 @@
+package protobuf
+
+import (
+	"context"
+	"testing"
+
+	"github.com/goatx/goat"
+	"github.com/goatx/goat/internal/e2egen"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestSerializeMessage(t *testing.T) {
+	type sampleMessage struct {
+		Message[*TestService1, *TestService1]
+
+		Foo    string
+		UserID string
+		Count  int
+		Event  goat.Event[*TestService1, *TestService1]
+		hidden string
+		_      int
+	}
+
+	msg := &sampleMessage{
+		Foo:    "foo",
+		UserID: "user-1",
+		Count:  3,
+		Event:  goat.Event[*TestService1, *TestService1]{},
+		hidden: "secret",
+	}
+
+	t.Run("filters non-protobuf fields and converts field names", func(t *testing.T) {
+		got := serializeMessage(msg)
+		want := map[string]any{
+			"Foo":    "foo",
+			"UserId": "user-1",
+			"Count":  3,
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("serializeMessage() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestBuildTestSuite(t *testing.T) {
+	t.Run("builds suite with single service and method", func(t *testing.T) {
+		opts := E2ETestOptions{
+			PackageName: "mypkg",
+			Services: []ServiceTestCase{
+				{
+					Spec:           newTestSpec(),
+					ServicePackage: "example/pkg",
+					Methods: []MethodTestCase{
+						{
+							MethodName: "Do",
+							Inputs: []AbstractMessage{
+								&TestRequest1{Data: "foo"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		got, err := buildTestSuite(opts)
+		if err != nil {
+			t.Fatalf("buildTestSuite() error = %v", err)
+		}
+
+		want := e2egen.TestSuite{
+			TestPackage: "mypkg",
+			Groups: []e2egen.TestGroup{
+				{
+					Name:          "TestService1",
+					SchemaPackage: "example/pkg",
+					Operations: []e2egen.Operation{
+						{
+							Name: "Do",
+							TestCases: []e2egen.TestCase{
+								{
+									Name:       "case_0",
+									InputType:  "TestRequest1",
+									Input:      map[string]any{"Data": "foo"},
+									OutputType: "TestResponse1",
+									Output:     map[string]any{"Result": "foo_out"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		if diff := cmp.Diff(want, got); diff != "" {
+			t.Fatalf("buildTestSuite() mismatch (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestExecuteHandler(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    AbstractServiceSpec
+		method  string
+		input   AbstractMessage
+		want    AbstractMessage
+		wantErr bool
+	}{
+		{
+			name:   "success",
+			spec:   newTestSpec(),
+			method: "Do",
+			input:  &TestRequest1{Data: "in"},
+			want:   &TestResponse1{Result: "in_out"},
+		},
+		{
+			name:    "missing handler",
+			spec:    newTestSpec(),
+			method:  "Nope",
+			input:   &TestRequest1{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := executeHandler(tt.spec, tt.method, tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("executeHandler() expected error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Fatalf("executeHandler() error = %v", err)
+			}
+
+			if diff := cmp.Diff(tt.want, got,
+				cmpopts.IgnoreUnexported(
+					goat.Event[*TestService1, *TestService1]{},
+				),
+			); diff != "" {
+				t.Fatalf("executeHandler() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func newTestSpec() *ServiceSpec[*TestService1] {
+	spec := NewServiceSpec(&TestService1{})
+	idle := &TestIdleState{}
+	spec.DefineStates(idle).SetInitialState(idle)
+
+	OnMessage(spec, idle, "Do",
+		func(ctx context.Context, req *TestRequest1, sm *TestService1) Response[*TestResponse1] {
+			return SendTo(ctx, sm, &TestResponse1{Result: req.Data + "_out"})
+		})
+
+	return spec
+}

--- a/protobuf/e2e_codegen.go
+++ b/protobuf/e2e_codegen.go
@@ -1,0 +1,257 @@
+package protobuf
+
+import (
+	"fmt"
+	"go/format"
+	"reflect"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/goatx/goat/internal/e2egen"
+	"github.com/goatx/goat/internal/strcase"
+)
+
+type testSuite struct {
+	suite e2egen.TestSuite
+}
+
+func (s *testSuite) generateMainTest() (string, error) {
+	var b strings.Builder
+
+	b.WriteString("package ")
+	b.WriteString(s.suite.TestPackage)
+	b.WriteString("\n\n")
+
+	b.WriteString("import (\n\t\"log\"\n\t\"net\"\n\t\"os\"\n\t\"testing\"\n\n\t\"google.golang.org/grpc\"\n")
+	seen := make(map[string]bool)
+	for _, group := range s.suite.Groups {
+		if seen[group.SchemaPackage] {
+			continue
+		}
+		b.WriteString("\tpb")
+		b.WriteString(strcase.ToSnakeCase(group.Name))
+		b.WriteString(" \"")
+		b.WriteString(group.SchemaPackage)
+		b.WriteString("\"\n")
+		seen[group.SchemaPackage] = true
+	}
+	b.WriteString(")\n\n")
+
+	for _, group := range s.suite.Groups {
+		snake := strcase.ToSnakeCase(group.Name)
+		clientVar := snake + "Client"
+		b.WriteString("var ")
+		b.WriteString(clientVar)
+		b.WriteString(" pb")
+		b.WriteString(snake)
+		b.WriteString(".")
+		b.WriteString(group.Name)
+		b.WriteString("Client\n")
+	}
+
+	b.WriteString("\nfunc TestMain(m *testing.M) {\n")
+	for i, group := range s.suite.Groups {
+		iStr := strconv.Itoa(i)
+		snake := strcase.ToSnakeCase(group.Name)
+		clientVar := snake + "Client"
+
+		b.WriteString("\tlis")
+		b.WriteString(iStr)
+		b.WriteString(", err := net.Listen(\"tcp\", \"localhost:0\")\n")
+		b.WriteString("\tif err != nil {\n\t\tlog.Fatalf(\"Failed to listen: %v\", err)\n\t}\n\n")
+
+		b.WriteString("\tgrpcServer")
+		b.WriteString(iStr)
+		b.WriteString(" := grpc.NewServer()\n")
+		b.WriteString("\tdefer grpcServer")
+		b.WriteString(iStr)
+		b.WriteString(".Stop()\n")
+		b.WriteString("\t// TODO: Register your service implementation here\n")
+		b.WriteString("\t// pb")
+		b.WriteString(snake)
+		b.WriteString(".Register")
+		b.WriteString(group.Name)
+		b.WriteString("Server(grpcServer")
+		b.WriteString(iStr)
+		b.WriteString(", &yourServiceImplementation{})\n\n")
+
+		b.WriteString("\tgo func() {\n\t\tif err := grpcServer")
+		b.WriteString(iStr)
+		b.WriteString(".Serve(lis")
+		b.WriteString(iStr)
+		b.WriteString("); err != nil {\n\t\t\tlog.Fatalf(\"Failed to serve: %v\", err)\n\t\t}\n\t}()\n\n")
+
+		b.WriteString("\tconn")
+		b.WriteString(iStr)
+		b.WriteString(", err := grpc.Dial(lis")
+		b.WriteString(iStr)
+		b.WriteString(".Addr().String(), grpc.WithInsecure())\n")
+		b.WriteString("\tif err != nil {\n\t\tlog.Fatalf(\"Failed to dial: %v\", err)\n\t}\n")
+		b.WriteString("\tdefer conn")
+		b.WriteString(iStr)
+		b.WriteString(".Close()\n\n")
+
+		b.WriteString("\t")
+		b.WriteString(clientVar)
+		b.WriteString(" = pb")
+		b.WriteString(snake)
+		b.WriteString(".New")
+		b.WriteString(group.Name)
+		b.WriteString("Client(conn")
+		b.WriteString(iStr)
+		b.WriteString(")\n\n")
+	}
+
+	b.WriteString("\tos.Exit(m.Run())\n}\n")
+
+	formatted, err := format.Source([]byte(b.String()))
+	if err != nil {
+		return b.String(), fmt.Errorf("failed to format: %w", err)
+	}
+	return string(formatted), nil
+}
+
+func (s *testSuite) generateServiceTest(group e2egen.TestGroup) (string, error) {
+	var b strings.Builder
+	snake := strcase.ToSnakeCase(group.Name)
+
+	b.WriteString("package ")
+	b.WriteString(s.suite.TestPackage)
+	b.WriteString("\n\nimport (\n\t\"testing\"\n\n\t\"github.com/google/go-cmp/cmp\"\n")
+	b.WriteString("\tpb")
+	b.WriteString(snake)
+	b.WriteString(" \"")
+	b.WriteString(group.SchemaPackage)
+	b.WriteString("\"\n")
+	b.WriteString(")\n\n")
+
+	for _, op := range group.Operations {
+		if err := s.writeMethodTest(&b, group, op); err != nil {
+			return "", err
+		}
+	}
+
+	formatted, err := format.Source([]byte(b.String()))
+	if err != nil {
+		return b.String(), fmt.Errorf("failed to format: %w", err)
+	}
+	return string(formatted), nil
+}
+
+func (*testSuite) writeMethodTest(b *strings.Builder, group e2egen.TestGroup, op e2egen.Operation) error {
+	if len(op.TestCases) == 0 {
+		return fmt.Errorf("no test cases for method %s", op.Name)
+	}
+
+	first := op.TestCases[0]
+	snake := strcase.ToSnakeCase(group.Name)
+	alias := "pb" + snake
+	clientVar := snake + "Client"
+
+	b.WriteString("func Test")
+	b.WriteString(op.Name)
+	b.WriteString("(t *testing.T) {\n")
+
+	b.WriteString("\ttests := []struct {\n\t\tname     string\n\t\tinput    *")
+	b.WriteString(alias)
+	b.WriteString(".")
+	b.WriteString(first.InputType)
+	b.WriteString("\n\t\texpected *")
+	b.WriteString(alias)
+	b.WriteString(".")
+	b.WriteString(first.OutputType)
+	b.WriteString("\n\t}{\n")
+
+	for _, tc := range op.TestCases {
+		b.WriteString("\t\t{\n")
+		b.WriteString("\t\t\tname: \"")
+		b.WriteString(tc.Name)
+		b.WriteString("\",\n")
+		b.WriteString("\t\t\tinput: ")
+		b.WriteString(formatStructLiteral(alias, tc.InputType, tc.Input))
+		b.WriteString(",\n")
+		b.WriteString("\t\t\texpected: ")
+		b.WriteString(formatStructLiteral(alias, tc.OutputType, tc.Output))
+		b.WriteString(",\n")
+		b.WriteString("\t\t},\n")
+	}
+
+	b.WriteString("\t}\n\n\tfor _, tt := range tests {\n\t\tt.Run(tt.name, func(t *testing.T) {\n")
+
+	b.WriteString("\t\t\tactual, err := ")
+	b.WriteString(clientVar)
+	b.WriteString(".")
+	b.WriteString(op.Name)
+	b.WriteString("(t.Context(), tt.input)\n")
+
+	b.WriteString("\t\t\tif err != nil {\n\t\t\t\tt.Fatalf(\"RPC call failed: %v\", err)\n\t\t\t}\n")
+
+	b.WriteString("\t\t\tif diff := cmp.Diff(tt.expected, actual); diff != \"\" {\n\t\t\t\tt.Errorf(\"")
+	b.WriteString(op.Name)
+	b.WriteString(" mismatch (-expected +actual):\\n%s\", diff)\n\t\t\t}\n")
+
+	b.WriteString("\t\t})\n\t}\n}\n\n")
+
+	return nil
+}
+
+func formatStructLiteral(pkgAlias, typeName string, data map[string]any) string {
+	if len(data) == 0 {
+		return "&" + pkgAlias + "." + typeName + "{}"
+	}
+
+	keys := make([]string, 0, len(data))
+	for k := range data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	b.WriteString("&")
+	b.WriteString(pkgAlias)
+	b.WriteString(".")
+	b.WriteString(typeName)
+	b.WriteString("{\n")
+
+	for _, k := range keys {
+		b.WriteString("\t\t\t\t")
+		b.WriteString(k)
+		b.WriteString(": ")
+		b.WriteString(formatValue(data[k]))
+		b.WriteString(",\n")
+	}
+	b.WriteString("\t\t\t}")
+	return b.String()
+}
+
+func formatValue(value any) string {
+	if value == nil {
+		return "nil"
+	}
+
+	v := reflect.ValueOf(value)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Slice, reflect.Map:
+		if v.IsNil() {
+			return "nil"
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.String:
+		return strconv.Quote(v.String())
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(v.Int(), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(v.Uint(), 10)
+	case reflect.Float32:
+		return strconv.FormatFloat(v.Float(), 'g', -1, 32)
+	case reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'g', -1, 64)
+	default:
+		return fmt.Sprintf("%#v", value)
+	}
+}

--- a/protobuf/e2e_codegen_test.go
+++ b/protobuf/e2e_codegen_test.go
@@ -1,0 +1,223 @@
+package protobuf
+
+import (
+	"testing"
+
+	"github.com/goatx/goat/internal/e2egen"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFormatStructLiteral(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		pkgAlias string
+		typeName string
+		data     map[string]any
+		want     string
+	}{
+		{
+			name:     "empty data",
+			pkgAlias: "pb",
+			typeName: "Request",
+			data:     map[string]any{},
+			want:     "&pb.Request{}",
+		},
+		{
+			name:     "populated data",
+			pkgAlias: "pb",
+			typeName: "Response",
+			data: map[string]any{
+				"Count":  5,
+				"Name":   "alice",
+				"Active": true,
+			},
+			want: "&pb.Response{\n\t\t\t\tActive: true,\n\t\t\t\tCount: 5,\n\t\t\t\tName: \"alice\",\n\t\t\t}",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatStructLiteral(tt.pkgAlias, tt.typeName, tt.data); got != tt.want {
+				t.Fatalf("FormatStructLiteral() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatValue(t *testing.T) {
+	t.Parallel()
+
+	var nilPtr *int
+
+	tests := []struct {
+		name  string
+		value any
+		want  string
+	}{
+		{name: "string", value: "hello", want: "\"hello\""},
+		{name: "bool", value: true, want: "true"},
+		{name: "int", value: int64(42), want: "42"},
+		{name: "uint", value: uint(7), want: "7"},
+		{name: "float32", value: float32(3.5), want: "3.5"},
+		{name: "float", value: 3.5, want: "3.5"},
+		{name: "slice", value: []int{1, 2}, want: "[]int{1, 2}"},
+		{name: "nil interface", value: nil, want: "nil"},
+		{name: "nil pointer", value: nilPtr, want: "nil"},
+		{name: "nil slice", value: []string(nil), want: "nil"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := formatValue(tt.value); got != tt.want {
+				t.Fatalf("FormatValue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateMainTest(t *testing.T) {
+	t.Parallel()
+
+	suite := e2egen.TestSuite{
+		TestPackage: "testpkg",
+		Groups: []e2egen.TestGroup{
+			{
+				Name:          "User",
+				SchemaPackage: "github.com/example/user",
+				Operations:    nil,
+			},
+		},
+	}
+
+	ts := &testSuite{suite: suite}
+	got, err := ts.generateMainTest()
+	if err != nil {
+		t.Fatalf("generateMainTest() error = %v", err)
+	}
+
+	want := `package testpkg
+
+import (
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	pbuser "github.com/example/user"
+	"google.golang.org/grpc"
+)
+
+var userClient pbuser.UserClient
+
+func TestMain(m *testing.M) {
+	lis0, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+
+	grpcServer0 := grpc.NewServer()
+	defer grpcServer0.Stop()
+	// TODO: Register your service implementation here
+	// pbuser.RegisterUserServer(grpcServer0, &yourServiceImplementation{})
+
+	go func() {
+		if err := grpcServer0.Serve(lis0); err != nil {
+			log.Fatalf("Failed to serve: %v", err)
+		}
+	}()
+
+	conn0, err := grpc.Dial(lis0.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn0.Close()
+
+	userClient = pbuser.NewUserClient(conn0)
+
+	os.Exit(m.Run())
+}
+`
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("generateMainTest() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGenerateServiceTest(t *testing.T) {
+	t.Parallel()
+
+	suite := e2egen.TestSuite{
+		TestPackage: "testpkg",
+	}
+	ts := &testSuite{suite: suite}
+
+	group := e2egen.TestGroup{
+		Name:          "User",
+		SchemaPackage: "github.com/example/user",
+		Operations: []e2egen.Operation{
+			{
+				Name: "CreateUser",
+				TestCases: []e2egen.TestCase{
+					{
+						Name:       "case_0",
+						InputType:  "CreateRequest",
+						Input:      map[string]any{"Foo": "bar"},
+						OutputType: "CreateResponse",
+						Output:     map[string]any{"Ok": true},
+					},
+				},
+			},
+		},
+	}
+
+	got, err := ts.generateServiceTest(group)
+	if err != nil {
+		t.Fatalf("generateServiceTest() error = %v", err)
+	}
+
+	want := `package testpkg
+
+import (
+	"testing"
+
+	pbuser "github.com/example/user"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCreateUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *pbuser.CreateRequest
+		expected *pbuser.CreateResponse
+	}{
+		{
+			name: "case_0",
+			input: &pbuser.CreateRequest{
+				Foo: "bar",
+			},
+			expected: &pbuser.CreateResponse{
+				Ok: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := userClient.CreateUser(t.Context(), tt.input)
+			if err != nil {
+				t.Fatalf("RPC call failed: %v", err)
+			}
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("CreateUser mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+`
+
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("generateServiceTest() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/protobuf/e2e_generator.go
+++ b/protobuf/e2e_generator.go
@@ -1,0 +1,71 @@
+package protobuf
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/goatx/goat/internal/strcase"
+)
+
+type MethodTestCase struct {
+	MethodName string
+	Inputs     []AbstractMessage
+}
+
+type ServiceTestCase struct {
+	Spec           AbstractServiceSpec
+	ServicePackage string
+	Methods        []MethodTestCase
+}
+
+type E2ETestOptions struct {
+	OutputDir   string
+	PackageName string
+	Services    []ServiceTestCase
+}
+
+func GenerateE2ETest(opts E2ETestOptions) error {
+	if opts.OutputDir == "" {
+		opts.OutputDir = "./tests"
+	}
+	if opts.PackageName == "" {
+		opts.PackageName = "main"
+	}
+
+	if err := os.MkdirAll(opts.OutputDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	suite, err := buildTestSuite(opts)
+	if err != nil {
+		return err
+	}
+
+	testSuite := &testSuite{suite: suite}
+
+	mainTest, err := testSuite.generateMainTest()
+	if err != nil {
+		return fmt.Errorf("failed to generate main_test.go: %w", err)
+	}
+
+	mainPath := filepath.Join(opts.OutputDir, "main_test.go")
+	if err := os.WriteFile(mainPath, []byte(mainTest), 0o600); err != nil {
+		return fmt.Errorf("failed to write main_test.go: %w", err)
+	}
+
+	for _, group := range suite.Groups {
+		serviceTest, err := testSuite.generateServiceTest(group)
+		if err != nil {
+			return fmt.Errorf("failed to generate test for %s: %w", group.Name, err)
+		}
+
+		filename := strcase.ToSnakeCase(group.Name) + "_test.go"
+		outputPath := filepath.Join(opts.OutputDir, filename)
+		if err := os.WriteFile(outputPath, []byte(serviceTest), 0o600); err != nil {
+			return fmt.Errorf("failed to write %s: %w", filename, err)
+		}
+	}
+
+	return nil
+}

--- a/protobuf/e2e_generator.go
+++ b/protobuf/e2e_generator.go
@@ -25,7 +25,9 @@ type E2ETestOptions struct {
 	Services    []ServiceTestCase
 }
 
-func GenerateE2ETest(opts E2ETestOptions) error {
+// GenerateMainTest generates main_test.go and writes it to the output directory.
+// This test file typically needs manual modification to register service implementations.
+func GenerateMainTest(opts E2ETestOptions) error {
 	if opts.OutputDir == "" {
 		opts.OutputDir = "./tests"
 	}
@@ -42,30 +44,62 @@ func GenerateE2ETest(opts E2ETestOptions) error {
 		return err
 	}
 
-	testSuite := &testSuite{suite: suite}
-
-	mainTest, err := testSuite.generateMainTest()
+	ts := &testSuite{suite: suite}
+	code, err := ts.generateMainTest()
 	if err != nil {
 		return fmt.Errorf("failed to generate main_test.go: %w", err)
 	}
 
 	mainPath := filepath.Join(opts.OutputDir, "main_test.go")
-	if err := os.WriteFile(mainPath, []byte(mainTest), 0o600); err != nil {
+	if err := os.WriteFile(mainPath, []byte(code), 0o600); err != nil {
 		return fmt.Errorf("failed to write main_test.go: %w", err)
 	}
 
+	return nil
+}
+
+// GenerateServiceTests generates test files for each service and writes them to the output directory.
+// These tests can be regenerated without affecting main_test.go.
+func GenerateServiceTests(opts E2ETestOptions) error {
+	if opts.OutputDir == "" {
+		opts.OutputDir = "./tests"
+	}
+	if opts.PackageName == "" {
+		opts.PackageName = "main"
+	}
+
+	if err := os.MkdirAll(opts.OutputDir, 0o750); err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	suite, err := buildTestSuite(opts)
+	if err != nil {
+		return err
+	}
+
+	ts := &testSuite{suite: suite}
+
 	for _, group := range suite.Groups {
-		serviceTest, err := testSuite.generateServiceTest(group)
+		code, err := ts.generateServiceTest(group)
 		if err != nil {
 			return fmt.Errorf("failed to generate test for %s: %w", group.Name, err)
 		}
 
 		filename := strcase.ToSnakeCase(group.Name) + "_test.go"
 		outputPath := filepath.Join(opts.OutputDir, filename)
-		if err := os.WriteFile(outputPath, []byte(serviceTest), 0o600); err != nil {
+		if err := os.WriteFile(outputPath, []byte(code), 0o600); err != nil {
 			return fmt.Errorf("failed to write %s: %w", filename, err)
 		}
 	}
 
 	return nil
+}
+
+// GenerateE2ETest generates all E2E test files and writes them to the output directory.
+// This is a convenience function that calls GenerateMainTest and GenerateServiceTests.
+func GenerateE2ETest(opts E2ETestOptions) error {
+	if err := GenerateMainTest(opts); err != nil {
+		return err
+	}
+	return GenerateServiceTests(opts)
 }

--- a/protobuf/example/.gitignore
+++ b/protobuf/example/.gitignore
@@ -1,0 +1,3 @@
+proto/user_service.proto
+e2e/main_test.go
+e2e/user_service_test.go

--- a/protobuf/example/e2e/main_test.go.golden
+++ b/protobuf/example/e2e/main_test.go.golden
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"log"
+	"net"
+	"os"
+	"testing"
+
+	pbuser_service "github.com/goatx/goat/protobuf/example/proto"
+	"google.golang.org/grpc"
+)
+
+var user_serviceClient pbuser_service.UserServiceClient
+
+func TestMain(m *testing.M) {
+	lis0, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		log.Fatalf("Failed to listen: %v", err)
+	}
+
+	grpcServer0 := grpc.NewServer()
+	defer grpcServer0.Stop()
+	// TODO: Register your service implementation here
+	// pbuser_service.RegisterUserServiceServer(grpcServer0, &yourServiceImplementation{})
+
+	go func() {
+		if err := grpcServer0.Serve(lis0); err != nil {
+			log.Fatalf("Failed to serve: %v", err)
+		}
+	}()
+
+	conn0, err := grpc.Dial(lis0.Addr().String(), grpc.WithInsecure())
+	if err != nil {
+		log.Fatalf("Failed to dial: %v", err)
+	}
+	defer conn0.Close()
+
+	user_serviceClient = pbuser_service.NewUserServiceClient(conn0)
+
+	os.Exit(m.Run())
+}

--- a/protobuf/example/e2e/user_service_test.go.golden
+++ b/protobuf/example/e2e/user_service_test.go.golden
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"testing"
+
+	pbuser_service "github.com/goatx/goat/protobuf/example/proto"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestCreateUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *pbuser_service.CreateUserRequest
+		expected *pbuser_service.CreateUserResponse
+	}{
+		{
+			name: "case_0",
+			input: &pbuser_service.CreateUserRequest{
+				Email:    "alice@example.com",
+				Tags:     nil,
+				Username: "alice",
+			},
+			expected: &pbuser_service.CreateUserResponse{
+				ErrorCode: 0,
+				Success:   true,
+				UserId:    "user_123",
+			},
+		},
+		{
+			name: "case_1",
+			input: &pbuser_service.CreateUserRequest{
+				Email:    "bob@example.com",
+				Tags:     nil,
+				Username: "bob",
+			},
+			expected: &pbuser_service.CreateUserResponse{
+				ErrorCode: 0,
+				Success:   true,
+				UserId:    "user_123",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := user_serviceClient.CreateUser(t.Context(), tt.input)
+			if err != nil {
+				t.Fatalf("RPC call failed: %v", err)
+			}
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("CreateUser mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestGetUser(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *pbuser_service.GetUserRequest
+		expected *pbuser_service.GetUserResponse
+	}{
+		{
+			name: "case_0",
+			input: &pbuser_service.GetUserRequest{
+				UserId: "user_123",
+			},
+			expected: &pbuser_service.GetUserResponse{
+				Email:    "test@example.com",
+				Found:    true,
+				Username: "testuser",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := user_serviceClient.GetUser(t.Context(), tt.input)
+			if err != nil {
+				t.Fatalf("RPC call failed: %v", err)
+			}
+			if diff := cmp.Diff(tt.expected, actual); diff != "" {
+				t.Errorf("GetUser mismatch (-expected +actual):\n%s", diff)
+			}
+		})
+	}
+}

--- a/protobuf/example/main.go
+++ b/protobuf/example/main.go
@@ -83,16 +83,44 @@ func createUserServiceModel() *protobuf.ServiceSpec[*UserService] {
 
 func main() {
 	spec := createUserServiceModel()
-
 	opts := protobuf.GenerateOptions{
 		OutputDir:   "./proto",
 		PackageName: "user.service",
-		GoPackage:   "github.com/goatx/goat/user/proto",
+		GoPackage:   "github.com/goatx/goat/protobuf/example/proto",
 		Filename:    "user_service.proto",
 	}
 
 	err := protobuf.Generate(opts, spec)
 	if err != nil {
 		log.Fatalf("Generate() error = %v", err)
+	}
+
+	err = protobuf.GenerateE2ETest(protobuf.E2ETestOptions{
+		OutputDir:   "./e2e",
+		PackageName: "main",
+		Services: []protobuf.ServiceTestCase{
+			{
+				Spec:           spec,
+				ServicePackage: "github.com/goatx/goat/protobuf/example/proto",
+				Methods: []protobuf.MethodTestCase{
+					{
+						MethodName: "CreateUser",
+						Inputs: []protobuf.AbstractMessage{
+							&CreateUserRequest{Username: "alice", Email: "alice@example.com"},
+							&CreateUserRequest{Username: "bob", Email: "bob@example.com"},
+						},
+					},
+					{
+						MethodName: "GetUser",
+						Inputs: []protobuf.AbstractMessage{
+							&GetUserRequest{UserID: "user_123"},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		log.Fatalf("GenerateE2ETest() error = %v", err)
 	}
 }

--- a/protobuf/example/main_test.go
+++ b/protobuf/example/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/goatx/goat/protobuf"
+	"github.com/google/go-cmp/cmp"
 )
 
 func TestUserServiceProtobufGeneration(t *testing.T) {
@@ -16,7 +17,7 @@ func TestUserServiceProtobufGeneration(t *testing.T) {
 	opts := protobuf.GenerateOptions{
 		OutputDir:   outputPath,
 		PackageName: "user.service",
-		GoPackage:   "github.com/goatx/goat/user/proto",
+		GoPackage:   "github.com/goatx/goat/protobuf/example/proto",
 		Filename:    "user_service.proto",
 	}
 
@@ -44,5 +45,69 @@ func TestUserServiceProtobufGeneration(t *testing.T) {
 
 	if got != want {
 		t.Errorf("Generated proto content mismatch.\nGot:\n%s\nWant:\n%s", got, want)
+	}
+}
+
+func TestUserServiceE2EGeneration(t *testing.T) {
+	spec := createUserServiceModel()
+	outputPath := filepath.Join(t.TempDir(), "e2e")
+
+	opts := protobuf.E2ETestOptions{
+		OutputDir:   outputPath,
+		PackageName: "main",
+		Services: []protobuf.ServiceTestCase{
+			{
+				Spec:           spec,
+				ServicePackage: "github.com/goatx/goat/protobuf/example/proto",
+				Methods: []protobuf.MethodTestCase{
+					{
+						MethodName: "CreateUser",
+						Inputs: []protobuf.AbstractMessage{
+							&CreateUserRequest{Username: "alice", Email: "alice@example.com"},
+							&CreateUserRequest{Username: "bob", Email: "bob@example.com"},
+						},
+					},
+					{
+						MethodName: "GetUser",
+						Inputs: []protobuf.AbstractMessage{
+							&GetUserRequest{UserID: "user_123"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := protobuf.GenerateE2ETest(opts)
+	if err != nil {
+		t.Fatalf("GenerateE2ETest() error = %v", err)
+	}
+
+	goldenFiles := []struct {
+		generated string
+		golden    string
+	}{
+		{"main_test.go", "main_test.go.golden"},
+		{"user_service_test.go", "user_service_test.go.golden"},
+	}
+
+	for _, gf := range goldenFiles {
+		generatedPath := filepath.Join(outputPath, gf.generated)
+		// #nosec G304 - generatedPath is constructed from t.TempDir() and fixed name in test
+		gotBytes, err := os.ReadFile(generatedPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", gf.generated, err)
+		}
+
+		goldenPath := filepath.Join("e2e", gf.golden)
+		// #nosec G304 - fixed golden path within repo
+		wantBytes, err := os.ReadFile(goldenPath)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) golden error = %v", gf.golden, err)
+		}
+
+		if diff := cmp.Diff(string(wantBytes), string(gotBytes)); diff != "" {
+			t.Errorf("%s mismatch (-want +got):\n%s", gf.generated, diff)
+		}
 	}
 }

--- a/protobuf/example/proto/user_service.proto.golden
+++ b/protobuf/example/proto/user_service.proto.golden
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package user.service;
 
-option go_package = "github.com/goatx/goat/user/proto";
+option go_package = "github.com/goatx/goat/protobuf/example/proto";
 
 message CreateUserRequest {
   string username = 1;

--- a/protobuf/types.go
+++ b/protobuf/types.go
@@ -1,8 +1,15 @@
 package protobuf
 
 import (
+	"context"
+	"reflect"
+	"strings"
+
 	"github.com/goatx/goat"
+	"github.com/goatx/goat/internal/typeutil"
 )
+
+type handlerFunc func(ctx context.Context, input AbstractMessage, sm goat.AbstractStateMachine) AbstractMessage
 
 type AbstractMessage interface {
 	isMessage() bool
@@ -19,28 +26,56 @@ func (*Message[Sender, Recipient]) isMessage() bool {
 	return true
 }
 
+func isMessageType(t reflect.Type) bool {
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Struct || t.PkgPath() != "github.com/goatx/goat/protobuf" {
+		return false
+	}
+
+	name := t.Name()
+	return strings.HasPrefix(name, "Message[")
+}
+
 type AbstractServiceSpec interface {
 	isServiceSpec() bool
-	GetRPCMethods() []rpcMethod
-	GetMessages() map[string]*message
+	getRPCMethods() []rpcMethod
+	getMessages() map[string]*message
+	getHandlers() map[string]handlerFunc
+	getServiceName() string
+	newInstance() (goat.AbstractStateMachine, error)
 }
 
 type ServiceSpec[T goat.AbstractStateMachine] struct {
 	*goat.StateMachineSpec[T]
 	rpcMethods []rpcMethod
 	messages   map[string]*message
+	handlers   map[string]handlerFunc
 }
 
 func (*ServiceSpec[T]) isServiceSpec() bool {
 	return true
 }
 
-func (ps *ServiceSpec[T]) GetRPCMethods() []rpcMethod {
+func (ps *ServiceSpec[T]) getRPCMethods() []rpcMethod {
 	return ps.rpcMethods
 }
 
-func (ps *ServiceSpec[T]) GetMessages() map[string]*message {
+func (ps *ServiceSpec[T]) getMessages() map[string]*message {
 	return ps.messages
+}
+
+func (ps *ServiceSpec[T]) getHandlers() map[string]handlerFunc {
+	return ps.handlers
+}
+
+func (*ServiceSpec[T]) getServiceName() string {
+	return typeutil.NameOf[T]()
+}
+
+func (ps *ServiceSpec[T]) newInstance() (goat.AbstractStateMachine, error) {
+	return ps.NewInstance()
 }
 
 func (ps *ServiceSpec[T]) addRPCMethod(metadata rpcMethod) {


### PR DESCRIPTION
Split GenerateE2ETest into:
- GenerateMainTest: generates and writes main_test.go
- GenerateServiceTests: generates and writes service test files

This allows users to:
- Generate main_test.go once and modify it manually
- Regenerate service tests via CI without overwriting main_test.go